### PR TITLE
[Feat] Clothes 추가 화면 구현 및 PhotoPicker 구현

### DIFF
--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		B4F1F42E2A18D81000DA6358 /* WeatherType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42D2A18D81000DA6358 /* WeatherType.swift */; };
 		B4F1F4302A18DB2400DA6358 /* UIView+Seperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */; };
 		B4F1F4342A19001200DA6358 /* AddPhotoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */; };
+		B4F1F4362A1914DF00DA6358 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -105,6 +106,7 @@
 		B4F1F42D2A18D81000DA6358 /* WeatherType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherType.swift; sourceTree = "<group>"; };
 		B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Seperator.swift"; sourceTree = "<group>"; };
 		B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoButton.swift; sourceTree = "<group>"; };
+		B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -290,6 +292,7 @@
 		B46CB8E72A148CE000039F72 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */,
 				B43889A72A14B28D00476BFC /* Preview */,
 				B46CB8E82A148D0B00039F72 /* Extensions */,
 			);
@@ -456,6 +459,7 @@
 				B4470B542A1741160024B2B7 /* ClothesViewModel.swift in Sources */,
 				B43889A02A14ACF600476BFC /* ClothesCategory.swift in Sources */,
 				B438897A2A14935200476BFC /* StyleController.swift in Sources */,
+				B4F1F4362A1914DF00DA6358 /* PhotoPicker.swift in Sources */,
 				B43889A22A14AD8800476BFC /* Clothes.swift in Sources */,
 				B46CB8B82A14739F00039F72 /* SceneDelegate.swift in Sources */,
 				B4F1F42C2A18D3E400DA6358 /* ClothesCategoryPickerView.swift in Sources */,

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -211,9 +211,9 @@
 			children = (
 				B46CB8B92A14739F00039F72 /* MainTabBarController.swift */,
 				B43889772A14934600476BFC /* ClothesController.swift */,
+				B4F1F4272A18C84D00DA6358 /* ClothesDetailController.swift */,
 				B438897B2A1493B400476BFC /* HomeController.swift */,
 				B43889792A14935200476BFC /* StyleController.swift */,
-				B4F1F4272A18C84D00DA6358 /* ClothesDetailController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -241,14 +241,14 @@
 			isa = PBXGroup;
 			children = (
 				B4F1F4262A18C34600DA6358 /* Protocol */,
-				B43889B22A150BF500476BFC /* ClothesCarouselCell.swift */,
-				B4470B4F2A1734780024B2B7 /* ClothesCategoryHeaderView.swift */,
-				B43889A82A14B7E600476BFC /* ClothesCell.swift */,
+				B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */,
 				B4470B572A17461E0024B2B7 /* AddPhotoCell.swift */,
 				B43889AE2A14C56500476BFC /* CarouselFlowLayout.swift */,
-				B4F1F41A2A17A90F00DA6358 /* InfoView.swift */,
+				B43889B22A150BF500476BFC /* ClothesCarouselCell.swift */,
+				B4470B4F2A1734780024B2B7 /* ClothesCategoryHeaderView.swift */,
 				B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */,
-				B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */,
+				B43889A82A14B7E600476BFC /* ClothesCell.swift */,
+				B4F1F41A2A17A90F00DA6358 /* InfoView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		B4F1F42C2A18D3E400DA6358 /* ClothesCategoryPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */; };
 		B4F1F42E2A18D81000DA6358 /* WeatherType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42D2A18D81000DA6358 /* WeatherType.swift */; };
 		B4F1F4302A18DB2400DA6358 /* UIView+Seperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */; };
+		B4F1F4342A19001200DA6358 /* AddPhotoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -103,6 +104,7 @@
 		B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesCategoryPickerView.swift; sourceTree = "<group>"; };
 		B4F1F42D2A18D81000DA6358 /* WeatherType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherType.swift; sourceTree = "<group>"; };
 		B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Seperator.swift"; sourceTree = "<group>"; };
+		B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -246,6 +248,7 @@
 				B43889AE2A14C56500476BFC /* CarouselFlowLayout.swift */,
 				B4F1F41A2A17A90F00DA6358 /* InfoView.swift */,
 				B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */,
+				B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -439,6 +442,7 @@
 				B4F1F42E2A18D81000DA6358 /* WeatherType.swift in Sources */,
 				B4470B582A17461E0024B2B7 /* AddPhotoCell.swift in Sources */,
 				B43889AD2A14B92600476BFC /* UICollectionView+RegisterDeque.swift in Sources */,
+				B4F1F4342A19001200DA6358 /* AddPhotoButton.swift in Sources */,
 				B43889AB2A14B8F300476BFC /* ReusableView.swift in Sources */,
 				B438897E2A1496C300476BFC /* DesignResources.swift in Sources */,
 				B438897C2A1493B400476BFC /* HomeController.swift in Sources */,

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		B4F1F4302A18DB2400DA6358 /* UIView+Seperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */; };
 		B4F1F4342A19001200DA6358 /* AddPhotoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */; };
 		B4F1F4362A1914DF00DA6358 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */; };
-		B4F1F4382A192B7D00DA6358 /* AddPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4372A192B7D00DA6358 /* AddPhotoView.swift */; };
+		B4F1F4382A192B7D00DA6358 /* PhotoHandlingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4372A192B7D00DA6358 /* PhotoHandlingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -108,7 +108,7 @@
 		B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Seperator.swift"; sourceTree = "<group>"; };
 		B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoButton.swift; sourceTree = "<group>"; };
 		B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
-		B4F1F4372A192B7D00DA6358 /* AddPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoView.swift; sourceTree = "<group>"; };
+		B4F1F4372A192B7D00DA6358 /* PhotoHandlingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoHandlingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -246,7 +246,7 @@
 			children = (
 				B4F1F4262A18C34600DA6358 /* Protocol */,
 				B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */,
-				B4F1F4372A192B7D00DA6358 /* AddPhotoView.swift */,
+				B4F1F4372A192B7D00DA6358 /* PhotoHandlingView.swift */,
 				B43889AE2A14C56500476BFC /* CarouselFlowLayout.swift */,
 				B43889B22A150BF500476BFC /* ClothesCarouselCell.swift */,
 				B4470B4F2A1734780024B2B7 /* ClothesCategoryHeaderView.swift */,
@@ -460,7 +460,7 @@
 				B4F1F4232A18AD9700DA6358 /* UITabBarController+Transition.swift in Sources */,
 				B4470B502A1734780024B2B7 /* ClothesCategoryHeaderView.swift in Sources */,
 				B4470B542A1741160024B2B7 /* ClothesViewModel.swift in Sources */,
-				B4F1F4382A192B7D00DA6358 /* AddPhotoView.swift in Sources */,
+				B4F1F4382A192B7D00DA6358 /* PhotoHandlingView.swift in Sources */,
 				B43889A02A14ACF600476BFC /* ClothesCategory.swift in Sources */,
 				B438897A2A14935200476BFC /* StyleController.swift in Sources */,
 				B4F1F4362A1914DF00DA6358 /* PhotoPicker.swift in Sources */,

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		B4F1F41B2A17A90F00DA6358 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F41A2A17A90F00DA6358 /* InfoView.swift */; };
 		B4F1F4232A18AD9700DA6358 /* UITabBarController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */; };
 		B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */; };
+		B4F1F4282A18C84D00DA6358 /* ClothesDetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4272A18C84D00DA6358 /* ClothesDetailController.swift */; };
+		B4F1F42C2A18D3E400DA6358 /* ClothesCategoryPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -95,6 +97,8 @@
 		B4F1F41A2A17A90F00DA6358 /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Transition.swift"; sourceTree = "<group>"; };
 		B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlightable.swift; sourceTree = "<group>"; };
+		B4F1F4272A18C84D00DA6358 /* ClothesDetailController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesDetailController.swift; sourceTree = "<group>"; };
+		B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesCategoryPickerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,6 +207,7 @@
 				B43889772A14934600476BFC /* ClothesController.swift */,
 				B438897B2A1493B400476BFC /* HomeController.swift */,
 				B43889792A14935200476BFC /* StyleController.swift */,
+				B4F1F4272A18C84D00DA6358 /* ClothesDetailController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -235,6 +240,7 @@
 				B4470B572A17461E0024B2B7 /* AddPhotoCell.swift */,
 				B43889AE2A14C56500476BFC /* CarouselFlowLayout.swift */,
 				B4F1F41A2A17A90F00DA6358 /* InfoView.swift */,
+				B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -430,6 +436,7 @@
 				B438897E2A1496C300476BFC /* DesignResources.swift in Sources */,
 				B438897C2A1493B400476BFC /* HomeController.swift in Sources */,
 				B43889A42A14B16D00476BFC /* UIViewPreview.swift in Sources */,
+				B4F1F4282A18C84D00DA6358 /* ClothesDetailController.swift in Sources */,
 				B4F1F41B2A17A90F00DA6358 /* InfoView.swift in Sources */,
 				B46CB8B62A14739F00039F72 /* AppDelegate.swift in Sources */,
 				B43889AF2A14C56500476BFC /* CarouselFlowLayout.swift in Sources */,
@@ -440,6 +447,7 @@
 				B438897A2A14935200476BFC /* StyleController.swift in Sources */,
 				B43889A22A14AD8800476BFC /* Clothes.swift in Sources */,
 				B46CB8B82A14739F00039F72 /* SceneDelegate.swift in Sources */,
+				B4F1F42C2A18D3E400DA6358 /* ClothesCategoryPickerView.swift in Sources */,
 				B4470B5A2A1766040024B2B7 /* UIView+Shadow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */; };
 		B4F1F4282A18C84D00DA6358 /* ClothesDetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4272A18C84D00DA6358 /* ClothesDetailController.swift */; };
 		B4F1F42C2A18D3E400DA6358 /* ClothesCategoryPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */; };
+		B4F1F42E2A18D81000DA6358 /* WeatherType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42D2A18D81000DA6358 /* WeatherType.swift */; };
+		B4F1F4302A18DB2400DA6358 /* UIView+Seperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -99,6 +101,8 @@
 		B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlightable.swift; sourceTree = "<group>"; };
 		B4F1F4272A18C84D00DA6358 /* ClothesDetailController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesDetailController.swift; sourceTree = "<group>"; };
 		B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesCategoryPickerView.swift; sourceTree = "<group>"; };
+		B4F1F42D2A18D81000DA6358 /* WeatherType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherType.swift; sourceTree = "<group>"; };
+		B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Seperator.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -218,6 +222,7 @@
 				B4470B552A1743130024B2B7 /* ClothesList.swift */,
 				B43889A12A14AD8800476BFC /* Clothes.swift */,
 				B438899F2A14ACF600476BFC /* ClothesCategory.swift */,
+				B4F1F42D2A18D81000DA6358 /* WeatherType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -294,6 +299,7 @@
 				B4470B512A1740AD0024B2B7 /* Array+SafeIndex.swift */,
 				B43889AC2A14B92600476BFC /* UICollectionView+RegisterDeque.swift */,
 				B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */,
+				B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */,
 				B4470B592A1766040024B2B7 /* UIView+Shadow.swift */,
 				B438899D2A14AB8E00476BFC /* UIViewController+NavigationTitle.swift */,
 			);
@@ -430,6 +436,7 @@
 				B43889A62A14B22100476BFC /* UIViewController+Preview.swift in Sources */,
 				B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */,
 				B43889B32A150BF500476BFC /* ClothesCarouselCell.swift in Sources */,
+				B4F1F42E2A18D81000DA6358 /* WeatherType.swift in Sources */,
 				B4470B582A17461E0024B2B7 /* AddPhotoCell.swift in Sources */,
 				B43889AD2A14B92600476BFC /* UICollectionView+RegisterDeque.swift in Sources */,
 				B43889AB2A14B8F300476BFC /* ReusableView.swift in Sources */,
@@ -448,6 +455,7 @@
 				B43889A22A14AD8800476BFC /* Clothes.swift in Sources */,
 				B46CB8B82A14739F00039F72 /* SceneDelegate.swift in Sources */,
 				B4F1F42C2A18D3E400DA6358 /* ClothesCategoryPickerView.swift in Sources */,
+				B4F1F4302A18DB2400DA6358 /* UIView+Seperator.swift in Sources */,
 				B4470B5A2A1766040024B2B7 /* UIView+Shadow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -37,7 +37,7 @@
 		B4470B522A1740AD0024B2B7 /* Array+SafeIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4470B512A1740AD0024B2B7 /* Array+SafeIndex.swift */; };
 		B4470B542A1741160024B2B7 /* ClothesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4470B532A1741160024B2B7 /* ClothesViewModel.swift */; };
 		B4470B562A1743130024B2B7 /* ClothesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4470B552A1743130024B2B7 /* ClothesList.swift */; };
-		B4470B582A17461E0024B2B7 /* AddPhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4470B572A17461E0024B2B7 /* AddPhotoCell.swift */; };
+		B4470B582A17461E0024B2B7 /* AddClothesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4470B572A17461E0024B2B7 /* AddClothesCell.swift */; };
 		B4470B5A2A1766040024B2B7 /* UIView+Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4470B592A1766040024B2B7 /* UIView+Shadow.swift */; };
 		B4470B5C2A176C3A0024B2B7 /* ShadowableCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4470B5B2A176C3A0024B2B7 /* ShadowableCellType.swift */; };
 		B46CB8B62A14739F00039F72 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46CB8B52A14739F00039F72 /* AppDelegate.swift */; };
@@ -54,6 +54,7 @@
 		B4F1F4302A18DB2400DA6358 /* UIView+Seperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */; };
 		B4F1F4342A19001200DA6358 /* AddPhotoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */; };
 		B4F1F4362A1914DF00DA6358 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */; };
+		B4F1F4382A192B7D00DA6358 /* AddPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4372A192B7D00DA6358 /* AddPhotoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -85,7 +86,7 @@
 		B4470B512A1740AD0024B2B7 /* Array+SafeIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeIndex.swift"; sourceTree = "<group>"; };
 		B4470B532A1741160024B2B7 /* ClothesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesViewModel.swift; sourceTree = "<group>"; };
 		B4470B552A1743130024B2B7 /* ClothesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesList.swift; sourceTree = "<group>"; };
-		B4470B572A17461E0024B2B7 /* AddPhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoCell.swift; sourceTree = "<group>"; };
+		B4470B572A17461E0024B2B7 /* AddClothesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddClothesCell.swift; sourceTree = "<group>"; };
 		B4470B592A1766040024B2B7 /* UIView+Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Shadow.swift"; sourceTree = "<group>"; };
 		B4470B5B2A176C3A0024B2B7 /* ShadowableCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowableCellType.swift; sourceTree = "<group>"; };
 		B46CB8B22A14739F00039F72 /* EasyCloset.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EasyCloset.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -107,6 +108,7 @@
 		B4F1F42F2A18DB2400DA6358 /* UIView+Seperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Seperator.swift"; sourceTree = "<group>"; };
 		B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoButton.swift; sourceTree = "<group>"; };
 		B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
+		B4F1F4372A192B7D00DA6358 /* AddPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -244,12 +246,13 @@
 			children = (
 				B4F1F4262A18C34600DA6358 /* Protocol */,
 				B4F1F4332A19001200DA6358 /* AddPhotoButton.swift */,
-				B4470B572A17461E0024B2B7 /* AddPhotoCell.swift */,
+				B4F1F4372A192B7D00DA6358 /* AddPhotoView.swift */,
 				B43889AE2A14C56500476BFC /* CarouselFlowLayout.swift */,
 				B43889B22A150BF500476BFC /* ClothesCarouselCell.swift */,
 				B4470B4F2A1734780024B2B7 /* ClothesCategoryHeaderView.swift */,
 				B4F1F42B2A18D3E400DA6358 /* ClothesCategoryPickerView.swift */,
 				B43889A82A14B7E600476BFC /* ClothesCell.swift */,
+				B4470B572A17461E0024B2B7 /* AddClothesCell.swift */,
 				B4F1F41A2A17A90F00DA6358 /* InfoView.swift */,
 			);
 			path = View;
@@ -443,7 +446,7 @@
 				B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */,
 				B43889B32A150BF500476BFC /* ClothesCarouselCell.swift in Sources */,
 				B4F1F42E2A18D81000DA6358 /* WeatherType.swift in Sources */,
-				B4470B582A17461E0024B2B7 /* AddPhotoCell.swift in Sources */,
+				B4470B582A17461E0024B2B7 /* AddClothesCell.swift in Sources */,
 				B43889AD2A14B92600476BFC /* UICollectionView+RegisterDeque.swift in Sources */,
 				B4F1F4342A19001200DA6358 /* AddPhotoButton.swift in Sources */,
 				B43889AB2A14B8F300476BFC /* ReusableView.swift in Sources */,
@@ -457,6 +460,7 @@
 				B4F1F4232A18AD9700DA6358 /* UITabBarController+Transition.swift in Sources */,
 				B4470B502A1734780024B2B7 /* ClothesCategoryHeaderView.swift in Sources */,
 				B4470B542A1741160024B2B7 /* ClothesViewModel.swift in Sources */,
+				B4F1F4382A192B7D00DA6358 /* AddPhotoView.swift in Sources */,
 				B43889A02A14ACF600476BFC /* ClothesCategory.swift in Sources */,
 				B438897A2A14935200476BFC /* StyleController.swift in Sources */,
 				B4F1F4362A1914DF00DA6358 /* PhotoPicker.swift in Sources */,

--- a/EasyCloset/EasyCloset/Resources/Info.plist
+++ b/EasyCloset/EasyCloset/Resources/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>옷 사진을 가져오기 위해 앨범 접근을 허용해주세요</string>
+	<key>NSCameraUsageDescription</key>
+	<string>옷 사진을 촬영하기 위해 카메라 사용을 허용해주세요</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Thin.otf</string>

--- a/EasyCloset/EasyCloset/Resources/Info.plist
+++ b/EasyCloset/EasyCloset/Resources/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>옷 사진을 가져오기 위해 앨범 접근을 허용해주세요</string>
 	<key>NSCameraUsageDescription</key>
 	<string>옷 사진을 촬영하기 위해 카메라 사용을 허용해주세요</string>
 	<key>UIAppFonts</key>

--- a/EasyCloset/EasyCloset/Sources/Model/Clothes.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/Clothes.swift
@@ -13,7 +13,7 @@ struct Clothes: Hashable {
   let imageURL: String
   var image: UIImage?
   var category: ClothesCategory
-  var weatherType: WeatherType?
+  var weatherType: WeatherType
   var description: String?
   
   init(id: UUID = UUID(),
@@ -21,7 +21,7 @@ struct Clothes: Hashable {
        imageURL: String,
        image: UIImage? = nil,
        category: ClothesCategory,
-       weatherType: WeatherType? = nil,
+       weatherType: WeatherType,
        description: String? = nil) {
     self.id = id
     self.createdAt = createdAt

--- a/EasyCloset/EasyCloset/Sources/Model/Clothes.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/Clothes.swift
@@ -9,32 +9,36 @@ import UIKit
 
 struct Clothes: Hashable {
   let id: UUID
-  var name: String
   let createdAt: Date
   let imageURL: String
   var image: UIImage?
   var category: ClothesCategory
+  var weatherType: WeatherType?
+  var description: String?
   
   init(id: UUID = UUID(),
-       name: String,
        createdAt: Date = Date(),
        imageURL: String,
-       image: UIImage?,
-       category: ClothesCategory) {
+       image: UIImage? = nil,
+       category: ClothesCategory,
+       weatherType: WeatherType? = nil,
+       description: String? = nil) {
     self.id = id
-    self.name = name
     self.createdAt = createdAt
     self.imageURL = imageURL
     self.image = image
     self.category = category
+    self.weatherType = weatherType
+    self.description = description
   }
   
   static var mock: Clothes {
     Clothes(
-      name: "\(Int.random(in: (1...100)))",
       imageURL: "",
       image: .Sample.cap1,
-      category: .allCases.randomElement()!
+      category: .allCases.randomElement()!,
+      weatherType: .allWeather,
+      description: "\(Int.random(in: (1...100)))"
     )
   }
 }

--- a/EasyCloset/EasyCloset/Sources/Model/ClothesCategory.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/ClothesCategory.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ClothesCategory: CaseIterable {
+enum ClothesCategory: Int, CaseIterable {
   case top
   case bottom
   case shoes

--- a/EasyCloset/EasyCloset/Sources/Model/ClothesList.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/ClothesList.swift
@@ -15,26 +15,38 @@ struct ClothesList {
       clothesByCategory:
         [
           .top: [
-            Clothes(imageURL: "", image: .Sample.tshirt1, category: .top, description: "tshirt1"),
-            Clothes(imageURL: "", image: .Sample.tshirt2, category: .top, description: "tshirt2"),
-            Clothes(imageURL: "", image: .Sample.shirt1, category: .top, description: "shirt1"),
-            Clothes(imageURL: "", image: .Sample.shirt2, category: .top, description: "shirt2"),
+            Clothes(imageURL: "", image: .Sample.tshirt1, category: .top,
+                    weatherType: .allWeather, description: "tshirt1"),
+            Clothes(imageURL: "", image: .Sample.tshirt2, category: .top,
+                    weatherType: .allWeather, description: "tshirt2"),
+            Clothes(imageURL: "", image: .Sample.shirt1, category: .top,
+                    weatherType: .allWeather, description: "shirt1"),
+            Clothes(imageURL: "", image: .Sample.shirt2, category: .top,
+                    weatherType: .allWeather, description: "shirt2")
           ],
           .bottom: [
-            Clothes(imageURL: "", image: .Sample.pants1, category: .bottom, description: "pants1"),
-            Clothes(imageURL: "", image: .Sample.pants2, category: .bottom, description: "pants2"),
-            Clothes(imageURL: "", image: .Sample.pants3, category: .bottom, description: "pants3"),
-            Clothes(imageURL: "", image: .Sample.shortpants, category: .bottom, description: "shortpants"),
+            Clothes(imageURL: "", image: .Sample.pants1, category: .bottom,
+                    weatherType: .allWeather, description: "pants1"),
+            Clothes(imageURL: "", image: .Sample.pants2, category: .bottom,
+                    weatherType: .allWeather, description: "pants2"),
+            Clothes(imageURL: "", image: .Sample.pants3, category: .bottom,
+                    weatherType: .allWeather, description: "pants3"),
+            Clothes(imageURL: "", image: .Sample.shortpants, category: .bottom,
+                    weatherType: .allWeather, description: "shortpants")
           ],
           .accessory: [
-            Clothes(imageURL: "", image: .Sample.cap1, category: .accessory, description: "cap1"),
-            Clothes(imageURL: "", image: .Sample.socks1, category: .accessory, description: "socks1")
+            Clothes(imageURL: "", image: .Sample.cap1, category: .accessory,
+                    weatherType: .allWeather, description: "cap1"),
+            Clothes(imageURL: "", image: .Sample.socks1, category: .accessory,
+                    weatherType: .allWeather, description: "socks1")
           ],
           .outer: [
-            Clothes(imageURL: "", image: .Sample.jacket1, category: .outer, description: "jacket1")
+            Clothes(imageURL: "", image: .Sample.jacket1, category: .outer,
+                    weatherType: .allWeather, description: "jacket1")
           ],
           .shoes: [
-            Clothes(imageURL: "", image: .Sample.shoes1, category: .shoes, description: "shoes1")
+            Clothes(imageURL: "", image: .Sample.shoes1, category: .shoes,
+                    weatherType: .allWeather, description: "shoes1")
           ]
         ]
     )

--- a/EasyCloset/EasyCloset/Sources/Model/ClothesList.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/ClothesList.swift
@@ -15,26 +15,26 @@ struct ClothesList {
       clothesByCategory:
         [
           .top: [
-            Clothes(name: "tshirt1", imageURL: "", image: .Sample.tshirt1, category: .top),
-            Clothes(name: "tshirt2", imageURL: "", image: .Sample.tshirt2, category: .top),
-            Clothes(name: "shirt1", imageURL: "", image: .Sample.shirt1, category: .top),
-            Clothes(name: "shirt2", imageURL: "", image: .Sample.shirt2, category: .top)
+            Clothes(imageURL: "", image: .Sample.tshirt1, category: .top, description: "tshirt1"),
+            Clothes(imageURL: "", image: .Sample.tshirt2, category: .top, description: "tshirt2"),
+            Clothes(imageURL: "", image: .Sample.shirt1, category: .top, description: "shirt1"),
+            Clothes(imageURL: "", image: .Sample.shirt2, category: .top, description: "shirt2"),
           ],
           .bottom: [
-            Clothes(name: "pants1", imageURL: "", image: .Sample.pants1, category: .bottom),
-            Clothes(name: "pants2", imageURL: "", image: .Sample.pants2, category: .bottom),
-            Clothes(name: "pants3", imageURL: "", image: .Sample.pants3, category: .bottom),
-            Clothes(name: "shortpants", imageURL: "", image: .Sample.shortpants, category: .bottom)
+            Clothes(imageURL: "", image: .Sample.pants1, category: .bottom, description: "pants1"),
+            Clothes(imageURL: "", image: .Sample.pants2, category: .bottom, description: "pants2"),
+            Clothes(imageURL: "", image: .Sample.pants3, category: .bottom, description: "pants3"),
+            Clothes(imageURL: "", image: .Sample.shortpants, category: .bottom, description: "shortpants"),
           ],
           .accessory: [
-            Clothes(name: "cap1", imageURL: "", image: .Sample.cap1, category: .accessory),
-            Clothes(name: "socks1", imageURL: "", image: .Sample.socks1, category: .accessory)
+            Clothes(imageURL: "", image: .Sample.cap1, category: .accessory, description: "cap1"),
+            Clothes(imageURL: "", image: .Sample.socks1, category: .accessory, description: "socks1")
           ],
           .outer: [
-            Clothes(name: "jacket1", imageURL: "", image: .Sample.jacket1, category: .outer)
+            Clothes(imageURL: "", image: .Sample.jacket1, category: .outer, description: "jacket1")
           ],
           .shoes: [
-            Clothes(name: "shoes1", imageURL: "", image: .Sample.shoes1, category: .shoes)
+            Clothes(imageURL: "", image: .Sample.shoes1, category: .shoes, description: "shoes1")
           ]
         ]
     )

--- a/EasyCloset/EasyCloset/Sources/Model/WeatherType.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/WeatherType.swift
@@ -1,0 +1,31 @@
+//
+//  WeatherType.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/20.
+//
+
+import Foundation
+
+enum WeatherType: Int, CaseIterable {
+  case allWeather
+  case spring
+  case summer
+  case fall
+  case winter
+  
+  var korean: String {
+    switch self {
+    case .allWeather:
+      return "사계절"
+    case .spring:
+      return "봄"
+    case .summer:
+      return "여름"
+    case .fall:
+      return "가을"
+    case .winter:
+      return "겨울"
+    }
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/Utils/Extensions/UICollectionView+RegisterDeque.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/Extensions/UICollectionView+RegisterDeque.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-extension UICollectionViewCell: ReusableView {}
 extension UICollectionReusableView: ReusableView {}
 
 extension UICollectionView {

--- a/EasyCloset/EasyCloset/Sources/Utils/Extensions/UIView+Seperator.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/Extensions/UIView+Seperator.swift
@@ -1,0 +1,21 @@
+//
+//  UIView+Seperator.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/20.
+//
+
+import UIKit
+
+import SnapKit
+
+extension UIView {
+  static var seperatorView: UIView {
+    let view = UIView()
+    view.backgroundColor = .seperator
+    view.snp.makeConstraints {
+      $0.height.equalTo(1)
+    }
+    return view
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/Utils/PhotoPicker.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/PhotoPicker.swift
@@ -1,0 +1,105 @@
+//
+//  PhotoController.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/20.
+//
+
+import UIKit
+
+import PhotosUI
+import Combine
+
+enum PhotoPickerError: Error {
+  case transferError(error: Error)
+  case invalidImage
+}
+
+final class PhotoPicker: NSObject {
+  
+  // MARK: - Properties
+  
+  private weak var viewController: UIViewController?
+  
+  private let imageSubject = PassthroughSubject<UIImage, PhotoPickerError>()
+  
+  // MARK: - Initialization
+  
+  init(parent viewController: UIViewController) {
+    self.viewController = viewController
+    super.init()
+  }
+  
+  // MARK: - Public Methods
+  
+  func requestCamera() -> AnyPublisher<UIImage, PhotoPickerError> {
+    let picker = UIImagePickerController()
+    picker.sourceType = .camera
+    picker.allowsEditing = true
+    picker.cameraDevice = .rear
+    picker.cameraCaptureMode = .photo
+    picker.delegate = self
+    
+    viewController?.present(picker, animated: true)
+    return imageSubject.eraseToAnyPublisher()
+  }
+  
+  func requestAlbum() -> AnyPublisher<UIImage, PhotoPickerError> {
+    var configuration = PHPickerConfiguration()
+    configuration.filter = .images
+    let picker = PHPickerViewController(configuration: configuration)
+    picker.delegate = self
+    
+    viewController?.present(picker, animated: true)
+    return imageSubject.eraseToAnyPublisher()
+  }
+  
+  // MARK: - Private Methods
+  func getDocumentsDirectory() -> URL? {
+    let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+    return paths.first
+  }
+}
+
+// MARK: - UIImagePickerControllerDelegate & UINavigationControllerDelegate
+// 카메라 촬영 _ UIImagePickerController
+extension PhotoPicker: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+  func imagePickerController(_ picker: UIImagePickerController,
+                             didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+    guard let image = info[.editedImage] as? UIImage else {
+      imageSubject.send(completion: .failure(.invalidImage))
+      return
+    }
+    
+    imageSubject.send(image)
+    picker.dismiss(animated: true)
+  }
+}
+
+// MARK: - PHPickerViewControllerDelegate
+// 갤러리 선택 _ PHPicker
+extension PhotoPicker: PHPickerViewControllerDelegate {
+  func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+    picker.dismiss(animated: true)
+    
+    let itemProvider = results.first?.itemProvider
+    guard let itemProvider = itemProvider,
+          itemProvider.canLoadObject(ofClass: UIImage.self) else { return }
+    
+    itemProvider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
+      guard let self = self else { return }
+      
+      if let error = error {
+        self.imageSubject.send(completion: .failure(.transferError(error: error)))
+      }
+      
+      DispatchQueue.main.async {
+        guard let image = image as? UIImage else {
+          self.imageSubject.send(completion: .failure(.invalidImage))
+          return
+        }
+        self.imageSubject.send(image)
+      }
+    }
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/View/AddClothesCell.swift
+++ b/EasyCloset/EasyCloset/Sources/View/AddClothesCell.swift
@@ -1,5 +1,5 @@
 //
-//  AddPhotoCell.swift
+//  AddClothesCell.swift
 //  EasyCloset
 //
 //  Created by Mason Kim on 2023/05/19.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class AddPhotoCell: UICollectionViewCell {
+final class AddClothesCell: UICollectionViewCell {
   
   // MARK: - UI Components
   
@@ -30,7 +30,7 @@ final class AddPhotoCell: UICollectionViewCell {
 
 // MARK: - UI & Layout
 
-extension AddPhotoCell {
+extension AddClothesCell {
   
   private func setup() {
     setUI()

--- a/EasyCloset/EasyCloset/Sources/View/AddPhotoButton.swift
+++ b/EasyCloset/EasyCloset/Sources/View/AddPhotoButton.swift
@@ -58,7 +58,7 @@ final class AddPhotoButton: UIButton {
     addSubview(bottomLabel)
     bottomLabel.snp.makeConstraints {
       $0.centerX.width.equalToSuperview()
-      $0.top.equalTo(iconImageView.snp.bottom)//.offset(8)
+      $0.top.equalTo(iconImageView.snp.bottom)
       $0.bottom.equalToSuperview().inset(spacing)
     }
   }

--- a/EasyCloset/EasyCloset/Sources/View/AddPhotoButton.swift
+++ b/EasyCloset/EasyCloset/Sources/View/AddPhotoButton.swift
@@ -6,7 +6,9 @@
 //
 
 import UIKit
+
 import SnapKit
+import Then
 
 final class AddPhotoButton: UIButton {
   

--- a/EasyCloset/EasyCloset/Sources/View/AddPhotoButton.swift
+++ b/EasyCloset/EasyCloset/Sources/View/AddPhotoButton.swift
@@ -1,0 +1,65 @@
+//
+//  AddPhotoButton.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/20.
+//
+
+import UIKit
+import SnapKit
+
+final class AddPhotoButton: UIButton {
+  
+  // MARK: - Properties
+  
+  private let iconImageView = UIImageView().then {
+    $0.tintColor = .white
+    $0.contentMode = .scaleAspectFit
+  }
+  
+  private let bottomLabel = UILabel().then {
+    $0.textColor = .white
+    $0.textAlignment = .center
+    $0.font = .pretendardMediumTitle
+  }
+  
+  // MARK: - Initialization
+  
+  init(title: String, image: UIImage?, spacing: CGFloat = 10) {
+    super.init(frame: .zero)
+    
+    iconImageView.image = image
+    bottomLabel.text = title
+    
+    setupUI()
+    setupLayout(spacing: spacing)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - UI & Layout
+  
+  private func setupUI() {
+    layer.cornerRadius = 8
+    backgroundColor = .black
+  }
+  
+  private func setupLayout(spacing: CGFloat) {
+    addSubview(iconImageView)
+    iconImageView.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(spacing)
+      $0.centerX.equalToSuperview()
+      $0.width.equalToSuperview().multipliedBy(0.5)
+      $0.height.equalTo(iconImageView.snp.width)
+    }
+
+    addSubview(bottomLabel)
+    bottomLabel.snp.makeConstraints {
+      $0.centerX.width.equalToSuperview()
+      $0.top.equalTo(iconImageView.snp.bottom)//.offset(8)
+      $0.bottom.equalToSuperview().inset(spacing)
+    }
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/View/AddPhotoView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/AddPhotoView.swift
@@ -1,0 +1,8 @@
+//
+//  AddPhotoView.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/21.
+//
+
+import Foundation

--- a/EasyCloset/EasyCloset/Sources/View/AddPhotoView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/AddPhotoView.swift
@@ -1,8 +1,0 @@
-//
-//  AddPhotoView.swift
-//  EasyCloset
-//
-//  Created by Mason Kim on 2023/05/21.
-//
-
-import Foundation

--- a/EasyCloset/EasyCloset/Sources/View/ClothesCarouselCell.swift
+++ b/EasyCloset/EasyCloset/Sources/View/ClothesCarouselCell.swift
@@ -114,7 +114,7 @@ extension ClothesCarouselCell {
   
   private func setupCollectionView() {
     collectionView.registerCell(cellClass: ClothesCell.self)
-    collectionView.registerCell(cellClass: AddPhotoCell.self)
+    collectionView.registerCell(cellClass: AddClothesCell.self)
     collectionView.delegate = self
   }
   
@@ -122,7 +122,7 @@ extension ClothesCarouselCell {
     DataSource(collectionView: collectionView) { collectionView, indexPath, item in
       switch item {
       case .addClothes:
-        return collectionView.dequeueReusableCell(cellClass: AddPhotoCell.self, for: indexPath)
+        return collectionView.dequeueReusableCell(cellClass: AddClothesCell.self, for: indexPath)
       case .clothes(let clothes):
         let cell = collectionView.dequeueReusableCell(cellClass: ClothesCell.self, for: indexPath)
         cell.configure(with: clothes)

--- a/EasyCloset/EasyCloset/Sources/View/ClothesCarouselCell.swift
+++ b/EasyCloset/EasyCloset/Sources/View/ClothesCarouselCell.swift
@@ -148,7 +148,11 @@ extension ClothesCarouselCell: UICollectionViewDelegate {
     case .clothes(let clothes):
       delegate?.clothesCarouselCell(self, showClothesDetail: clothes)
     }
-    
+
+    // 자연스럽게 보이도록 0.5초 후에 해당 위치로 scroll
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+      self.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+    }
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/View/ClothesCategoryPickerView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/ClothesCategoryPickerView.swift
@@ -34,12 +34,13 @@ final class ClothesCategoryPickerView: UIPickerView {
 
 extension ClothesCategoryPickerView: UIPickerViewDelegate {
   
+  // 폰트를 설정하기 위해 viewForRow 로 설정해줌
   func pickerView(_ pickerView: UIPickerView, viewForRow row: Int,
                   forComponent component: Int, reusing view: UIView?) -> UIView {
     let label = (view as? UILabel) ?? UILabel()
     label.font = .pretendardContent
     label.textAlignment = .center
-    label.text = ClothesCategory.allCases[safe: row]?.korean ?? ""
+    label.text = ClothesCategory(rawValue: row)?.korean ?? ""
     return label
   }
 }

--- a/EasyCloset/EasyCloset/Sources/View/ClothesCategoryPickerView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/ClothesCategoryPickerView.swift
@@ -24,6 +24,7 @@ final class ClothesCategoryPickerView: UIPickerView {
   
   private func setup() {
     dataSource = self
+    delegate = self
     backgroundColor = .white.withAlphaComponent(0.5)
     layer.cornerRadius = 16
   }
@@ -32,9 +33,14 @@ final class ClothesCategoryPickerView: UIPickerView {
 // MARK: - UIPickerViewDelegate
 
 extension ClothesCategoryPickerView: UIPickerViewDelegate {
-  override func selectRow(_ row: Int, inComponent component: Int, animated: Bool) {
-    guard let category = ClothesCategory.allCases[safe: row] else { return }
-    // TODO: 카테고리 선택 넘기기
+  
+  func pickerView(_ pickerView: UIPickerView, viewForRow row: Int,
+                  forComponent component: Int, reusing view: UIView?) -> UIView {
+    let label = (view as? UILabel) ?? UILabel()
+    label.font = .pretendardContent
+    label.textAlignment = .center
+    label.text = ClothesCategory.allCases[safe: row]?.korean ?? ""
+    return label
   }
 }
 
@@ -49,9 +55,4 @@ extension ClothesCategoryPickerView: UIPickerViewDataSource {
   func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
     return ClothesCategory.allCases.count
   }
-  
-  func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-    return ClothesCategory.allCases[safe: row]?.korean ?? ""
-  }
-  
 }

--- a/EasyCloset/EasyCloset/Sources/View/ClothesCategoryPickerView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/ClothesCategoryPickerView.swift
@@ -1,0 +1,56 @@
+//
+//  ClothesCategoryPicker.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/20.
+//
+
+import UIKit
+
+final class ClothesCategoryPickerView: UIPickerView {
+
+  // MARK: - Initialization
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setup()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Private Methods
+  
+  private func setup() {
+    dataSource = self
+    
+  }
+}
+
+// MARK: - UIPickerViewDelegate
+
+extension ClothesCategoryPickerView: UIPickerViewDelegate {
+  override func selectRow(_ row: Int, inComponent component: Int, animated: Bool) {
+    guard let category = ClothesCategory.allCases[safe: row] else { return }
+    // TODO: 카테고리 선택 넘기기
+  }
+}
+
+// MARK: - UIPickerViewDataSource
+
+extension ClothesCategoryPickerView: UIPickerViewDataSource {
+  
+  func numberOfComponents(in pickerView: UIPickerView) -> Int {
+    return 1
+  }
+  
+  func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    return ClothesCategory.allCases.count
+  }
+  
+  func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+    return ClothesCategory.allCases[safe: row]?.korean ?? ""
+  }
+  
+}

--- a/EasyCloset/EasyCloset/Sources/View/ClothesCategoryPickerView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/ClothesCategoryPickerView.swift
@@ -24,7 +24,8 @@ final class ClothesCategoryPickerView: UIPickerView {
   
   private func setup() {
     dataSource = self
-    
+    backgroundColor = .white.withAlphaComponent(0.5)
+    layer.cornerRadius = 16
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/View/ClothesCell.swift
+++ b/EasyCloset/EasyCloset/Sources/View/ClothesCell.swift
@@ -54,7 +54,7 @@ final class ClothesCell: UICollectionViewCell, Highlightable {
   // MARK: - Public Methods
   
   func configure(with clothes: Clothes) {
-    nameLabel.text = clothes.name
+    nameLabel.text = "#\(clothes.category.korean)"
     clothesImageView.image = clothes.image
   }
   

--- a/EasyCloset/EasyCloset/Sources/View/InfoView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/InfoView.swift
@@ -21,10 +21,6 @@ final class InfoView: UIControl, Highlightable {
     $0.contentMode = .scaleAspectFit
   }
   
-  private let seperatorView = UIView().then {
-    $0.backgroundColor = .seperator
-  }
-  
   private let infoLabel = UILabel()
   
   // MARK: - Initialization
@@ -90,9 +86,9 @@ extension InfoView {
       $0.top.horizontalEdges.equalToSuperview()
     }
     
+    let seperatorView = UIView.seperatorView
     containerView.addSubview(seperatorView)
     seperatorView.snp.makeConstraints {
-      $0.height.equalTo(1)
       $0.horizontalEdges.equalToSuperview()
       $0.bottom.equalTo(infoImageView.snp.bottom)
     }

--- a/EasyCloset/EasyCloset/Sources/View/PhotoHandlingView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/PhotoHandlingView.swift
@@ -1,0 +1,203 @@
+//
+//  PhotoHandlingView.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/21.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+import Combine
+
+final class PhotoHandlingView: UIStackView {
+  
+  enum PhotoState {
+    case empty
+    case show
+    case added
+    case editing
+  }
+  
+  // MARK: - Properties
+  
+  var state: PhotoState = .empty {
+    didSet {
+      configure(with: state)
+    }
+  }
+  
+  private let photoPicker: PhotoPicker
+  
+  private var cancellables = Set<AnyCancellable>()
+
+  // MARK: - Initialization
+  
+  init(with photoPicker: PhotoPicker) {
+    self.photoPicker = photoPicker
+    super.init(frame: .zero)
+    setupLayout()
+  }
+  
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - UI Components
+  
+  private let clothesImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+    $0.backgroundColor = .white
+  }
+  
+  private let addPhotoLabel = UILabel().then {
+    $0.text = "사진 등록하기"
+    $0.font = .pretendardLargeTitle
+  }
+  
+  private lazy var cameraButton = AddPhotoButton(
+    title: "카메라",
+    image: UIImage(systemName: "camera.fill")).then {
+      $0.addTarget(self, action: #selector(tappedCameraButton), for: .touchUpInside)
+    }
+  private lazy var galleryButton = AddPhotoButton(
+    title: "사진첩",
+    image: UIImage(systemName: "photo.fill")).then {
+      $0.addTarget(self, action: #selector(tappedGalleryButton), for: .touchUpInside)
+    }
+  
+  private lazy var addPhotoStackView = UIStackView(arrangedSubviews: [
+    cameraButton, galleryButton
+  ]).then {
+    $0.axis = .horizontal
+    $0.spacing = 20
+  }
+  
+  private lazy var photoRemoveButton = UIButton().then {
+    $0.setImage(UIImage(systemName: "trash"), for: .normal)
+    $0.tintColor = .systemRed
+    $0.isHidden = true
+    $0.addTarget(self, action: #selector(didRemovePhoto), for: .valueChanged)
+  }
+  
+  // MARK: - Public Methods
+  
+  func setImage(_ image: UIImage?) {
+    clothesImageView.image = image
+    state = .show
+  }
+  
+  // MARK: - Private Methods
+  
+  private func configure(with state: PhotoState) {
+    // 사진이 있으면, 사진추가 관련 뷰들을 숨김
+    let addPhotoIsHidden = state != .empty
+    setAddPhotoView(isHidden: addPhotoIsHidden)
+    
+    // 아무 사진도 없거나 / 편집없이 보기만 하는 상태면, 사진 삭제 버튼을 숨김
+    let removePhotoIsHidden = (state == .empty || state == .show)
+    photoRemoveButton.isHidden = removePhotoIsHidden
+  }
+  
+  private func setAddPhotoView(isHidden: Bool) {
+    addPhotoStackView.isHidden = isHidden
+    addPhotoLabel.isHidden = isHidden
+  }
+  
+  @objc private func tappedCameraButton() {
+    photoPicker.requestCamera()
+      .sink { completion in
+        if case .failure(let error) = completion {
+          // TODO: 실패 alert 띄우기
+          print("실패..... \(error)")
+        }
+      } receiveValue: { [weak self] image in
+        self?.clothesImageView.image = image
+        self?.state = .added
+//        self?.isPhotoAdded = true
+      }
+      .store(in: &cancellables)
+  }
+  
+  @objc private func tappedGalleryButton() {
+    photoPicker.requestAlbum()
+      .sink { completion in
+        if case .failure(let error) = completion {
+          // TODO: 실패 alert 띄우기
+          print("실패..... \(error)")
+        }
+      } receiveValue: { [weak self] image in
+        self?.clothesImageView.image = image
+        self?.state = .added
+      }
+      .store(in: &cancellables)
+  }
+  
+  @objc private func didRemovePhoto() {
+    state = .empty
+  }
+}
+
+// MARK: - UI & Layout
+
+extension PhotoHandlingView {
+  
+  private func setupLayout() {
+    setupclothesImageViewLayout()
+    setupAddPhotoButtonsLayout()
+    setupPhotoRemoveButtonLayout()
+  }
+  
+  private func setupclothesImageViewLayout() {
+    addArrangedSubview(clothesImageView)
+    clothesImageView.snp.makeConstraints {
+      $0.width.equalTo(clothesImageView.snp.height)
+    }
+  }
+  
+  private func setupAddPhotoButtonsLayout() {
+    [cameraButton, galleryButton].forEach { button in
+      button.snp.makeConstraints {
+        $0.width.equalTo(80)
+        $0.height.equalTo(90)
+      }
+    }
+    addSubview(addPhotoStackView)
+    addPhotoStackView.snp.makeConstraints {
+      $0.center.equalTo(clothesImageView)
+    }
+    
+    addSubview(addPhotoLabel)
+    addPhotoLabel.snp.makeConstraints {
+      $0.bottom.equalTo(addPhotoStackView.snp.top).inset(-20)
+      $0.centerX.equalTo(addPhotoStackView)
+    }
+  }
+  
+  private func setupPhotoRemoveButtonLayout() {
+    addSubview(photoRemoveButton)
+    photoRemoveButton.snp.makeConstraints {
+      $0.bottom.equalTo(clothesImageView.snp.bottom)
+      $0.centerX.equalTo(addPhotoStackView)
+      $0.height.width.equalTo(80)
+    }
+  }
+}
+
+// MARK: - Preview
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct AddPhotoViewPreview: PreviewProvider {
+  static var previews: some View {
+    UIViewPreview {
+      PhotoHandlingView(with: .init(parent: UIViewController()))
+    }
+    .frame(height: 180)
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesController.swift
@@ -117,7 +117,7 @@ extension ClothesController: UICollectionViewDataSource {
   func collectionView(_ collectionView: UICollectionView,
                       cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(cellClass: ClothesCarouselCell.self, for: indexPath)
-    if let category = ClothesCategory.allCases[safe: indexPath.section] {
+    if let category = ClothesCategory(rawValue: indexPath.section) {
       cell.bind(to: viewModel, with: category)
     }
     
@@ -133,7 +133,7 @@ extension ClothesController: UICollectionViewDataSource {
       ofType: ClothesCategoryHeaderView.self,
       for: indexPath)
     
-    if let category = ClothesCategory.allCases[safe: indexPath.section] {
+    if let category = ClothesCategory(rawValue: indexPath.section) {
       headerView.configure(with: category)
     }
     

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesController.swift
@@ -156,11 +156,14 @@ extension ClothesController: UICollectionViewDelegateFlowLayout {
 extension ClothesController: ClothesCarouselCellDelegate {
   
   func clothesCarouselCell(_ cell: ClothesCarouselCell, showClothesDetail clothes: Clothes) {
-    // TODO: 옷 상세정보 나타내기
+    let detailController = ClothesDetailController(type: .showDetail)
+    detailController.configure(with: clothes)
+    navigationController?.pushViewController(detailController, animated: true)
   }
   
   func clothesCarouselCell(_ cell: ClothesCarouselCell, addClothesOf categoty: ClothesCategory) {
-    // TODO: 옷 추가하기
+    let detailController = ClothesDetailController(type: .add)
+    navigationController?.pushViewController(detailController, animated: true)
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
@@ -1,0 +1,152 @@
+//
+//  ClothesDetailController.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/20.
+//
+
+import UIKit
+
+final class ClothesDetailController: UIViewController {
+  
+  enum ControllerType {
+    case add
+    case showDetail
+  }
+  
+  // MARK: - Constants
+  
+  private enum Metric { }
+  
+  // MARK: - Properties
+  
+  private let type: ControllerType
+  
+  // MARK: - UI Components
+  
+  private let scrollView = UIScrollView()
+  private let contentStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 16
+    $0.layoutMargins = UIEdgeInsets(top: 16, left: 20, bottom: 0, right: 20)
+    $0.isLayoutMarginsRelativeArrangement = true
+  }
+  
+  private let clothesImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+    $0.backgroundColor = .white
+  }
+  
+  private let addPhotoLabel = UILabel().then {
+    $0.text = "사진 등록하기"
+    $0.font = .pretendardMediumTitle
+  }
+  
+  private let cameraButton = UIButton()
+  private let galleryButton = UIButton()
+  private lazy var addPhotoStackView = UIStackView(arrangedSubviews: [
+    cameraButton, galleryButton
+  ]).then {
+    $0.axis = .horizontal
+    $0.spacing = 20
+  }
+  
+  private let categotyPickerView = ClothesCategoryPickerView()
+  
+  // MARK: - Initialization
+  
+  init(type: ControllerType) {
+    self.type = type
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Lifecycle
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setup()
+  }
+  
+  // MARK: - Public Methods
+  
+  func configure(with clothes: Clothes) {
+    guard type == .showDetail else { return }
+  }
+  
+  // MARK: - Private Methods
+  
+}
+
+// MARK: - UI & Layout
+
+extension ClothesDetailController {
+  
+  private func setup() {
+    setUI()
+    setupLayout()
+  }
+  
+  private func setUI() {
+    switch type {
+    case .add:
+      title = "옷 추가하기"
+    case .showDetail:
+      title = "옷 상세보기"
+    }
+    view.backgroundColor = .background
+  }
+  
+  private func setupLayout() {
+    view.addSubview(scrollView)
+    scrollView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    scrollView.addSubview(contentStackView)
+    contentStackView.snp.makeConstraints {
+      $0.edges.width.equalToSuperview()
+    }
+    
+    contentStackView.addArrangedSubview(clothesImageView)
+    clothesImageView.snp.makeConstraints {
+      $0.width.equalTo(clothesImageView.snp.height)
+    }
+    
+    contentStackView.addArrangedSubview(headerLabel(with: "카테고리"))
+    contentStackView.addArrangedSubview(categotyPickerView)
+    categotyPickerView.snp.makeConstraints {
+      $0.height.equalTo(100)
+    }
+    
+    contentStackView.addArrangedSubview(headerLabel(with: "계절"))
+  }
+  
+  private func headerLabel(with title: String) -> UILabel {
+    let label = UILabel()
+    label.text = title
+    label.font = .pretendardMediumTitle
+    label.snp.makeConstraints {
+      $0.height.equalTo(60)
+    }
+    label.backgroundColor = .lightGray
+    return label
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+import SwiftUI
+
+struct ClothesDetailControllerPreview: PreviewProvider {
+  static var previews: some View {
+    UINavigationController(
+      rootViewController: ClothesDetailController(type: .add)
+    ).toPreview()
+  }
+}
+#endif

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
@@ -9,14 +9,14 @@ import UIKit
 
 final class ClothesDetailController: UIViewController {
   
-  enum ControllerType {
-    case add
-    case showDetail
-  }
-  
   // MARK: - Properties
   
-  private let type: ControllerType
+  private let type: ClothesDetailControllerType
+  private var isEditingClothes = false {
+    didSet {
+      turnEditMode(isOn: isEditingClothes)
+    }
+  }
   
   // MARK: - UI Components
   
@@ -62,9 +62,15 @@ final class ClothesDetailController: UIViewController {
     $0.placeholder = "설명을 입력해주세요 (선택)"
   }
   
+  private lazy var editAddBarButton = UIBarButtonItem(
+    title: type.rightBarButtonTitle,
+    style: .plain,
+    target: self,
+    action: #selector(tappedEditAddButton))
+  
   // MARK: - Initialization
   
-  init(type: ControllerType) {
+  init(type: ClothesDetailControllerType) {
     self.type = type
     super.init(nibName: nil, bundle: nil)
   }
@@ -90,16 +96,13 @@ final class ClothesDetailController: UIViewController {
   func configure(with clothes: Clothes) {
     guard type == .showDetail else { return }
     
+    clothesImageView.image = clothes.image
     categotyPickerView.selectRow(clothes.category.rawValue,
                                  inComponent: 0, animated: false)
-    clothesImageView.image = clothes.image
-    if let weatherType = clothes.weatherType {
-      weatherSegmentedControl.selectedSegmentIndex = weatherType.rawValue
-    }
+    weatherSegmentedControl.selectedSegmentIndex = clothes.weatherType.rawValue
     if let description = clothes.description {
       descriptionTextField.text = description
     }
-    
     turnEditMode(isOn: false)
   }
   
@@ -109,6 +112,29 @@ final class ClothesDetailController: UIViewController {
     categotyPickerView.isUserInteractionEnabled = isOn
     weatherSegmentedControl.isUserInteractionEnabled = isOn
     descriptionTextField.isUserInteractionEnabled = isOn
+  }
+  
+  @objc private func tappedEditAddButton() {
+    switch type {
+    case .add:
+      addClothes()
+    case .showDetail:
+      editClothes()
+    }
+  }
+  
+  private func addClothes() {
+    navigationController?.popViewController(animated: true)
+  }
+  
+  private func editClothes() {
+    if isEditingClothes {
+      isEditingClothes = false
+      editAddBarButton.title = "편집"
+    } else {
+      isEditingClothes = true
+      editAddBarButton.title = "완료"
+    }
   }
   
   @objc private func didSelectWeather(_ sender: UISegmentedControl) {
@@ -126,12 +152,8 @@ extension ClothesDetailController {
   }
   
   private func setUI() {
-    switch type {
-    case .add:
-      title = "옷 추가하기"
-    case .showDetail:
-      title = "옷 상세보기"
-    }
+    title = type.title
+    navigationItem.rightBarButtonItem = editAddBarButton
     view.backgroundColor = .background
   }
   
@@ -207,6 +229,31 @@ extension ClothesDetailController {
       }
     }
     contentStackView.addArrangedSubview(label)
+  }
+}
+
+// MARK: - ClothesDetailControllerType
+
+enum ClothesDetailControllerType {
+  case add
+  case showDetail
+  
+  var title: String {
+    switch self {
+    case .add:
+      return "옷 추가하기"
+    case .showDetail:
+      return "옷 상세하기"
+    }
+  }
+  
+  var rightBarButtonTitle: String {
+    switch self {
+    case .add:
+      return "추가"
+    case .showDetail:
+      return "편집"
+    }
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
@@ -27,7 +27,7 @@ final class ClothesDetailController: UIViewController {
   private let scrollView = UIScrollView()
   private let contentStackView = UIStackView().then {
     $0.axis = .vertical
-    $0.spacing = 16
+//    $0.spacing = 16
     $0.layoutMargins = UIEdgeInsets(top: 16, left: 20, bottom: 0, right: 20)
     $0.isLayoutMarginsRelativeArrangement = true
   }
@@ -53,6 +53,16 @@ final class ClothesDetailController: UIViewController {
   
   private let categotyPickerView = ClothesCategoryPickerView()
   
+  private lazy var weatherSegmentedControl = UISegmentedControl(
+    items: WeatherType.allCases.map { $0.korean }
+  ).then {
+    $0.addTarget(self, action: #selector(didSelectWeather), for: .valueChanged)
+  }
+  
+  private let descriptionTextField = UITextField().then {
+    $0.placeholder = "설명을 입력해주세요 (선택)"
+  }
+  
   // MARK: - Initialization
   
   init(type: ControllerType) {
@@ -71,6 +81,11 @@ final class ClothesDetailController: UIViewController {
     setup()
   }
   
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    super.touchesBegan(touches, with: event)
+    descriptionTextField.resignFirstResponder()
+  }
+  
   // MARK: - Public Methods
   
   func configure(with clothes: Clothes) {
@@ -79,6 +94,11 @@ final class ClothesDetailController: UIViewController {
   
   // MARK: - Private Methods
   
+  @objc private func didSelectWeather(_ sender: UISegmentedControl) {
+    guard let weatherType = WeatherType(rawValue: sender.selectedSegmentIndex) else { return }
+  }
+  
+
 }
 
 // MARK: - UI & Layout
@@ -101,6 +121,14 @@ extension ClothesDetailController {
   }
   
   private func setupLayout() {
+    setupScrollViewLayout()
+    setupclothesImageViewLayout()
+    setupSection(with: "카테고리", view: categotyPickerView, viewHeight: 100, spacing: 16)
+    setupSection(with: "계절", view: weatherSegmentedControl, viewHeight: 30, spacing: 40)
+    setupSection(with: "설명", view: descriptionTextField, spacing: 16)
+  }
+  
+  private func setupScrollViewLayout() {
     view.addSubview(scrollView)
     scrollView.snp.makeConstraints {
       $0.edges.equalToSuperview()
@@ -110,30 +138,37 @@ extension ClothesDetailController {
     contentStackView.snp.makeConstraints {
       $0.edges.width.equalToSuperview()
     }
-    
+  }
+  
+  private func setupclothesImageViewLayout() {
     contentStackView.addArrangedSubview(clothesImageView)
+    contentStackView.setCustomSpacing(30, after: clothesImageView)
     clothesImageView.snp.makeConstraints {
       $0.width.equalTo(clothesImageView.snp.height)
     }
-    
-    contentStackView.addArrangedSubview(headerLabel(with: "카테고리"))
-    contentStackView.addArrangedSubview(categotyPickerView)
-    categotyPickerView.snp.makeConstraints {
-      $0.height.equalTo(100)
-    }
-    
-    contentStackView.addArrangedSubview(headerLabel(with: "계절"))
   }
   
-  private func headerLabel(with title: String) -> UILabel {
-    let label = UILabel()
-    label.text = title
-    label.font = .pretendardMediumTitle
-    label.snp.makeConstraints {
-      $0.height.equalTo(60)
+  private func setupSection(with title: String, view: UIView,
+                            viewHeight: CGFloat? = nil, spacing: CGFloat) {
+    addHeaderLabel(with: title)
+    contentStackView.addArrangedSubview(view)
+    contentStackView.setCustomSpacing(spacing, after: view)
+    guard let height = viewHeight else { return }
+    view.snp.makeConstraints {
+      $0.height.equalTo(height)
     }
-    label.backgroundColor = .lightGray
-    return label
+  }
+  
+  private func addHeaderLabel(with title: String) {
+    contentStackView.addArrangedSubview(.seperatorView)
+    let label = UILabel().then { label in
+      label.text = title
+      label.font = .pretendardMediumTitle
+      label.snp.makeConstraints {
+        $0.height.equalTo(60)
+      }
+    }
+    contentStackView.addArrangedSubview(label)
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
@@ -243,7 +243,7 @@ enum ClothesDetailControllerType {
     case .add:
       return "옷 추가하기"
     case .showDetail:
-      return "옷 상세하기"
+      return "옷 상세보기"
     }
   }
   

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
@@ -14,10 +14,6 @@ final class ClothesDetailController: UIViewController {
     case showDetail
   }
   
-  // MARK: - Constants
-  
-  private enum Metric { }
-  
   // MARK: - Properties
   
   private let type: ControllerType
@@ -27,7 +23,6 @@ final class ClothesDetailController: UIViewController {
   private let scrollView = UIScrollView()
   private let contentStackView = UIStackView().then {
     $0.axis = .vertical
-//    $0.spacing = 16
     $0.layoutMargins = UIEdgeInsets(top: 16, left: 20, bottom: 0, right: 20)
     $0.isLayoutMarginsRelativeArrangement = true
   }
@@ -39,11 +34,15 @@ final class ClothesDetailController: UIViewController {
   
   private let addPhotoLabel = UILabel().then {
     $0.text = "사진 등록하기"
-    $0.font = .pretendardMediumTitle
+    $0.font = .pretendardLargeTitle
   }
   
-  private let cameraButton = UIButton()
-  private let galleryButton = UIButton()
+  private let cameraButton = AddPhotoButton(
+    title: "카메라",
+    image: UIImage(systemName: "camera.fill"))
+  private let galleryButton = AddPhotoButton(
+    title: "사진첩",
+    image: UIImage(systemName: "photo.fill"))
   private lazy var addPhotoStackView = UIStackView(arrangedSubviews: [
     cameraButton, galleryButton
   ]).then {
@@ -90,15 +89,31 @@ final class ClothesDetailController: UIViewController {
   
   func configure(with clothes: Clothes) {
     guard type == .showDetail else { return }
+    
+    categotyPickerView.selectRow(clothes.category.rawValue,
+                                 inComponent: 0, animated: false)
+    clothesImageView.image = clothes.image
+    if let weatherType = clothes.weatherType {
+      weatherSegmentedControl.selectedSegmentIndex = weatherType.rawValue
+    }
+    if let description = clothes.description {
+      descriptionTextField.text = description
+    }
+    
+    turnEditMode(isOn: false)
   }
   
   // MARK: - Private Methods
   
+  private func turnEditMode(isOn: Bool) {
+    categotyPickerView.isUserInteractionEnabled = isOn
+    weatherSegmentedControl.isUserInteractionEnabled = isOn
+    descriptionTextField.isUserInteractionEnabled = isOn
+  }
+  
   @objc private func didSelectWeather(_ sender: UISegmentedControl) {
     guard let weatherType = WeatherType(rawValue: sender.selectedSegmentIndex) else { return }
   }
-  
-
 }
 
 // MARK: - UI & Layout
@@ -126,6 +141,10 @@ extension ClothesDetailController {
     setupSection(with: "카테고리", view: categotyPickerView, viewHeight: 100, spacing: 16)
     setupSection(with: "계절", view: weatherSegmentedControl, viewHeight: 30, spacing: 40)
     setupSection(with: "설명", view: descriptionTextField, spacing: 16)
+    
+    if type == .add {
+      setupAddPhotoButtons()
+    }
   }
   
   private func setupScrollViewLayout() {
@@ -145,6 +164,25 @@ extension ClothesDetailController {
     contentStackView.setCustomSpacing(30, after: clothesImageView)
     clothesImageView.snp.makeConstraints {
       $0.width.equalTo(clothesImageView.snp.height)
+    }
+  }
+  
+  private func setupAddPhotoButtons() {
+    [cameraButton, galleryButton].forEach { button in
+      button.snp.makeConstraints {
+        $0.width.equalTo(80)
+        $0.height.equalTo(90)
+      }
+    }
+    view.addSubview(addPhotoStackView)
+    addPhotoStackView.snp.makeConstraints {
+      $0.center.equalTo(clothesImageView)
+    }
+    
+    view.addSubview(addPhotoLabel)
+    addPhotoLabel.snp.makeConstraints {
+      $0.bottom.equalTo(addPhotoStackView.snp.top).inset(-20)
+      $0.centerX.equalTo(addPhotoStackView)
     }
   }
   
@@ -179,9 +217,9 @@ import SwiftUI
 
 struct ClothesDetailControllerPreview: PreviewProvider {
   static var previews: some View {
-    UINavigationController(
-      rootViewController: ClothesDetailController(type: .add)
-    ).toPreview()
+    let vc = ClothesDetailController(type: .showDetail)
+    vc.configure(with: Clothes.mock)
+    return UINavigationController(rootViewController: vc).toPreview()
   }
 }
 #endif


### PR DESCRIPTION
### Clothes 모델 수정 - 계절 정보 모델 추가

### PhotoPicker 구현
  - 사진 촬영: UIPickerController
  - 앨범 선택: PHPicker 로 구현
  - Combine 으로 성공/실패 값을 reactive하게 보내도록 처리함

### PhotoPicker 의 Combine을 Future로 변경
- 사진 선택의 특성 상 값이 하나만 보내고 바로 finished 되는 성격이 더 적합하다 판단되어 Futurue로 변경
- delegate 에서 작업을 넘겨받기 위해, completionHandler 클로저를 프로퍼티로 만들어 처리함

### ✨PhotoHandlingView 로 사진 관련 뷰 로직을 분리
- ClothesDetail 뷰컨을 모두 CodeUI로 작성하다 보니 뷰컨이 400줄 가까이 넘어가는 현상이 발생했고, 코드의 흐름이 뒤섞이는 느낌이 듬
- 내부에서 가장 많은 부분을 차지하는 것이 옷 사진을 나타내거나 / 추가하거나 / 편집하는 부분이었음. 
- 옷 사진 관련 정보를 핸들링하는 뷰들을 모두 따로 분리해서 커스텀 뷰로 만듬 -> 이후 약 180줄 정도의 코드가 `PhotoHandlingView`로 넘어갔고, 뷰의 계층도 좀 더 보기 좋게 변경됨.
> 커밋 헤더에는 실수로 적지 못했기에 커밋 번호 남김
   해당 커밋: 52f2610cb22246d051207bbffd186df140e4cb1f

### 사진 편집 / 추가 관련 상태를 보기 좋게 변경
  - Bool 타입의 플래그 2개를 번갈아 사용하던 형태를, 
  - enum 형태로 state 를 관리해서 명시적이게 변경함
```swift
  enum PhotoState {
    case empty
    case show
    case added
    case editing
  }
```