### PR TITLE
[Feat] 이미지 디스크 캐싱(NSCache), 메모리 저장(FileManager) 구현

### DIFF
--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		B49CAAD12A1B5455008254C7 /* StyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD02A1B5455008254C7 /* StyleViewModel.swift */; };
 		B49CAAD52A1B8AD6008254C7 /* UIImage+Collage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */; };
 		B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */; };
+		B4E5C56A2A1C9E3E00B14F48 /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */; };
 		B4F1F41B2A17A90F00DA6358 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F41A2A17A90F00DA6358 /* InfoView.swift */; };
 		B4F1F4232A18AD9700DA6358 /* UITabBarController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */; };
 		B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */; };
@@ -115,6 +116,7 @@
 		B49CAAD02A1B5455008254C7 /* StyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleViewModel.swift; sourceTree = "<group>"; };
 		B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Collage.swift"; sourceTree = "<group>"; };
 		B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
+		B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
 		B4F1F41A2A17A90F00DA6358 /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Transition.swift"; sourceTree = "<group>"; };
 		B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlightable.swift; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 				B4470B592A1766040024B2B7 /* UIView+Shadow.swift */,
 				B438899D2A14AB8E00476BFC /* UIViewController+NavigationTitle.swift */,
 				B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */,
+				B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -534,6 +537,7 @@
 				B438897C2A1493B400476BFC /* HomeController.swift in Sources */,
 				B43889A42A14B16D00476BFC /* UIViewPreview.swift in Sources */,
 				B4F1F4282A18C84D00DA6358 /* ClothesDetailController.swift in Sources */,
+				B4E5C56A2A1C9E3E00B14F48 /* UIImage+Resize.swift in Sources */,
 				B44EA8B72A1B2F6A008A83FF /* ClothesStorage.swift in Sources */,
 				B4F1F41B2A17A90F00DA6358 /* InfoView.swift in Sources */,
 				B46CB8B62A14739F00039F72 /* AppDelegate.swift in Sources */,

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -56,7 +56,7 @@
 		B49CAAD52A1B8AD6008254C7 /* UIImage+Collage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */; };
 		B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */; };
 		B4E5C56A2A1C9E3E00B14F48 /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */; };
-		B4E5C56C2A1CAC0C00B14F48 /* ImageFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C56B2A1CAC0C00B14F48 /* ImageFileManager.swift */; };
+		B4E5C56C2A1CAC0C00B14F48 /* ImageFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C56B2A1CAC0C00B14F48 /* ImageFileStorage.swift */; };
 		B4F1F41B2A17A90F00DA6358 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F41A2A17A90F00DA6358 /* InfoView.swift */; };
 		B4F1F4232A18AD9700DA6358 /* UITabBarController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */; };
 		B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */; };
@@ -118,7 +118,7 @@
 		B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Collage.swift"; sourceTree = "<group>"; };
 		B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
-		B4E5C56B2A1CAC0C00B14F48 /* ImageFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileManager.swift; sourceTree = "<group>"; };
+		B4E5C56B2A1CAC0C00B14F48 /* ImageFileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileStorage.swift; sourceTree = "<group>"; };
 		B4F1F41A2A17A90F00DA6358 /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Transition.swift"; sourceTree = "<group>"; };
 		B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlightable.swift; sourceTree = "<group>"; };
@@ -324,6 +324,7 @@
 			isa = PBXGroup;
 			children = (
 				B44EA8B62A1B2F6A008A83FF /* ClothesStorage.swift */,
+				B4E5C56B2A1CAC0C00B14F48 /* ImageFileStorage.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -333,7 +334,6 @@
 			children = (
 				B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */,
 				B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */,
-				B4E5C56B2A1CAC0C00B14F48 /* ImageFileManager.swift */,
 				B43889A72A14B28D00476BFC /* Preview */,
 				B46CB8E82A148D0B00039F72 /* Extensions */,
 			);
@@ -559,7 +559,7 @@
 				B4F1F42C2A18D3E400DA6358 /* ClothesCategoryPickerView.swift in Sources */,
 				B4F1F4302A18DB2400DA6358 /* UIView+Seperator.swift in Sources */,
 				B4470B5A2A1766040024B2B7 /* UIView+Shadow.swift in Sources */,
-				B4E5C56C2A1CAC0C00B14F48 /* ImageFileManager.swift in Sources */,
+				B4E5C56C2A1CAC0C00B14F48 /* ImageFileStorage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		B49CAAD52A1B8AD6008254C7 /* UIImage+Collage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */; };
 		B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */; };
 		B4E5C56A2A1C9E3E00B14F48 /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */; };
+		B4E5C56C2A1CAC0C00B14F48 /* ImageFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C56B2A1CAC0C00B14F48 /* ImageFileManager.swift */; };
 		B4F1F41B2A17A90F00DA6358 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F41A2A17A90F00DA6358 /* InfoView.swift */; };
 		B4F1F4232A18AD9700DA6358 /* UITabBarController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */; };
 		B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */; };
@@ -117,6 +118,7 @@
 		B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Collage.swift"; sourceTree = "<group>"; };
 		B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
+		B4E5C56B2A1CAC0C00B14F48 /* ImageFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileManager.swift; sourceTree = "<group>"; };
 		B4F1F41A2A17A90F00DA6358 /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Transition.swift"; sourceTree = "<group>"; };
 		B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlightable.swift; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 			children = (
 				B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */,
 				B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */,
+				B4E5C56B2A1CAC0C00B14F48 /* ImageFileManager.swift */,
 				B43889A72A14B28D00476BFC /* Preview */,
 				B46CB8E82A148D0B00039F72 /* Extensions */,
 			);
@@ -556,6 +559,7 @@
 				B4F1F42C2A18D3E400DA6358 /* ClothesCategoryPickerView.swift in Sources */,
 				B4F1F4302A18DB2400DA6358 /* UIView+Seperator.swift in Sources */,
 				B4470B5A2A1766040024B2B7 /* UIView+Shadow.swift in Sources */,
+				B4E5C56C2A1CAC0C00B14F48 /* ImageFileManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		B49CAACF2A1B5169008254C7 /* StyleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAACE2A1B5169008254C7 /* StyleCell.swift */; };
 		B49CAAD12A1B5455008254C7 /* StyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD02A1B5455008254C7 /* StyleViewModel.swift */; };
 		B49CAAD52A1B8AD6008254C7 /* UIImage+Collage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */; };
+		B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */; };
 		B4F1F41B2A17A90F00DA6358 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F41A2A17A90F00DA6358 /* InfoView.swift */; };
 		B4F1F4232A18AD9700DA6358 /* UITabBarController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */; };
 		B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */; };
@@ -113,6 +114,7 @@
 		B49CAACE2A1B5169008254C7 /* StyleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleCell.swift; sourceTree = "<group>"; };
 		B49CAAD02A1B5455008254C7 /* StyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleViewModel.swift; sourceTree = "<group>"; };
 		B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Collage.swift"; sourceTree = "<group>"; };
+		B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		B4F1F41A2A17A90F00DA6358 /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		B4F1F4222A18AD9700DA6358 /* UITabBarController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Transition.swift"; sourceTree = "<group>"; };
 		B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlightable.swift; sourceTree = "<group>"; };
@@ -326,6 +328,7 @@
 			isa = PBXGroup;
 			children = (
 				B4F1F4352A1914DF00DA6358 /* PhotoPicker.swift */,
+				B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */,
 				B43889A72A14B28D00476BFC /* Preview */,
 				B46CB8E82A148D0B00039F72 /* Extensions */,
 			);
@@ -515,6 +518,7 @@
 				B49CAACF2A1B5169008254C7 /* StyleCell.swift in Sources */,
 				B46CB8BA2A14739F00039F72 /* MainTabBarController.swift in Sources */,
 				B4470B5C2A176C3A0024B2B7 /* ShadowableCellType.swift in Sources */,
+				B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */,
 				B4470B562A1743130024B2B7 /* ClothesList.swift in Sources */,
 				B43889A92A14B7E600476BFC /* ClothesCell.swift in Sources */,
 				B43889A62A14B22100476BFC /* UIViewController+Preview.swift in Sources */,

--- a/EasyCloset/EasyCloset/Sources/Data/Storage/ImageFileStorage.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Storage/ImageFileStorage.swift
@@ -1,5 +1,5 @@
 //
-//  ImageFileManager.swift
+//  ImageFileStorage.swift
 //  EasyCloset
 //
 //  Created by Mason Kim on 2023/05/23.
@@ -7,11 +7,11 @@
 
 import UIKit
 
-final class ImageFileManager {
+final class ImageFileStorage {
   
   // MARK: - Singleton
   
-  static let shared = ImageFileManager()
+  static let shared = ImageFileStorage()
   
   private init() { }
   
@@ -34,6 +34,7 @@ final class ImageFileManager {
     }
   }
   
+  @discardableResult
   func remove(withID id: UUID) -> Bool {
     guard let filePath = filePath(of: id) else { return false }
     

--- a/EasyCloset/EasyCloset/Sources/Utils/Extensions/UIImage+Collage.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/Extensions/UIImage+Collage.swift
@@ -36,27 +36,3 @@ extension Array where Element == UIImage {
     return collageImage
   }
 }
-
-extension UIImage {
-  func scaled(to newSize: CGSize, isKeepingRatio: Bool = true) -> UIImage {
-    guard size != newSize else { return self }
-    
-    // 가로, 세로 변환 비율
-    let widthRatio  = newSize.width  / size.width
-    let heightRatio = newSize.height / size.height
-    
-    var scaledSize = newSize
-    if isKeepingRatio {
-      let scalingFactor = min(widthRatio, heightRatio)
-      scaledSize = CGSize(width: size.width * scalingFactor,
-                          height: size.height * scalingFactor)
-    }
-    
-    let render = UIGraphicsImageRenderer(size: scaledSize)
-    let renderedImage = render.image { _ in
-      self.draw(in: CGRect(origin: .zero, size: scaledSize))
-    }
-    
-    return renderedImage
-  }
-}

--- a/EasyCloset/EasyCloset/Sources/Utils/Extensions/UIImage+Resize.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/Extensions/UIImage+Resize.swift
@@ -1,0 +1,32 @@
+//
+//  UIImage+Resize.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/23.
+//
+
+import UIKit
+
+extension UIImage {
+  func scaled(to newSize: CGSize, isKeepingRatio: Bool = true) -> UIImage {
+    guard size != newSize else { return self }
+    
+    // 가로, 세로 변환 비율
+    let widthRatio  = newSize.width  / size.width
+    let heightRatio = newSize.height / size.height
+    
+    var scaledSize = newSize
+    if isKeepingRatio {
+      let scalingFactor = min(widthRatio, heightRatio)
+      scaledSize = CGSize(width: size.width * scalingFactor,
+                          height: size.height * scalingFactor)
+    }
+    
+    let render = UIGraphicsImageRenderer(size: scaledSize)
+    let renderedImage = render.image { _ in
+      self.draw(in: CGRect(origin: .zero, size: scaledSize))
+    }
+    
+    return renderedImage
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/Utils/ImageCacheManager.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/ImageCacheManager.swift
@@ -9,22 +9,36 @@ import UIKit
 
 final class ImageCacheManager {
   
-  // MARK: - Properties
-  static let shared = ImageCacheManager()
-  private let cacheManager =  NSCache<NSString, UIImage>()
+  // MARK: - Configuration
   
-  // MARK: - LifeCycle
-  
-  private init() {}
-  
-  // MARK: - Public
-  
-  func get(for key: String) -> UIImage? {
-    cacheManager.object(forKey: key as NSString)
+  private enum Configuration {
+    static let countLimit = 100 // 총 100개 까지만 FIFO로 캐싱함
+    static let megaByteLimit = 200 * megaByteUnit // 메모리 캐싱에 200메가바이트 만큼 제약을 줌
+    static let megaByteUnit = 1024 * 1024
   }
   
-  func store(_ value: UIImage, for key: String) {
-    cacheManager.setObject(value, forKey: key as NSString)
+  // MARK: - Singleton
+  
+  static let shared = ImageCacheManager()
+  
+  private init() {
+    cache.countLimit = Configuration.countLimit
+    cache.totalCostLimit = Configuration.megaByteLimit
+  }
+  
+  // MARK: - Properties
+  
+  private let cache = NSCache<NSString, UIImage>()
+  
+  // MARK: - Public Methods
+  
+  func get(for id: UUID) -> UIImage? {
+    cache.object(forKey: id.uuidString as NSString)
+  }
+  
+  func store(_ value: UIImage, for id: UUID) {
+    let bytesOfImage = value.jpegData(compressionQuality: 1.0)?.count ?? 0
+    cache.setObject(value, forKey: id.uuidString as NSString, cost: bytesOfImage)
   }
   
 }

--- a/EasyCloset/EasyCloset/Sources/Utils/ImageCacheManager.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/ImageCacheManager.swift
@@ -1,0 +1,30 @@
+//
+//  ImageCacheManager.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/23.
+//
+
+import UIKit
+
+final class ImageCacheManager {
+  
+  // MARK: - Properties
+  static let shared = ImageCacheManager()
+  private let cacheManager =  NSCache<NSString, UIImage>()
+  
+  // MARK: - LifeCycle
+  
+  private init() {}
+  
+  // MARK: - Public
+  
+  func get(for key: String) -> UIImage? {
+    cacheManager.object(forKey: key as NSString)
+  }
+  
+  func store(_ value: UIImage, for key: String) {
+    cacheManager.setObject(value, forKey: key as NSString)
+  }
+  
+}

--- a/EasyCloset/EasyCloset/Sources/Utils/ImageCacheManager.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/ImageCacheManager.swift
@@ -13,7 +13,7 @@ final class ImageCacheManager {
   
   private enum Configuration {
     static let countLimit = 100 // 총 100개 까지만 FIFO로 캐싱함
-    static let megaByteLimit = 200 * megaByteUnit // 메모리 캐싱에 200메가바이트 만큼 제약을 줌
+    static let megaByteLimit = 200 * megaByteUnit // 메모리 캐싱에 (대략) 200메가바이트 만큼 제약을 줌
     static let megaByteUnit = 1024 * 1024
   }
   

--- a/EasyCloset/EasyCloset/Sources/Utils/ImageFileManager.swift
+++ b/EasyCloset/EasyCloset/Sources/Utils/ImageFileManager.swift
@@ -1,0 +1,63 @@
+//
+//  ImageFileManager.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/23.
+//
+
+import UIKit
+
+final class ImageFileManager {
+  
+  // MARK: - Singleton
+  
+  static let shared = ImageFileManager()
+  
+  private init() { }
+  
+  // MARK: - Public Methods
+
+  func save(image: UIImage, id: UUID) throws {
+    guard let data = image.jpegData(compressionQuality: 1.0),
+          let filePath = filePath(of: id) else { return }
+    
+    try data.write(to: filePath)
+  }
+  
+  func load(withID id: UUID) -> UIImage? {
+    guard let filePath = filePath(of: id) else { return nil }
+    do {
+      let data = try Data(contentsOf: filePath)
+      return UIImage(data: data)
+    } catch {
+      return nil
+    }
+  }
+  
+  func remove(withID id: UUID) -> Bool {
+    guard let filePath = filePath(of: id) else { return false }
+    
+    do {
+      try FileManager.default.removeItem(at: filePath)
+      return true
+    } catch {
+      return false
+    }
+  }
+  
+  // MARK: - Private Methods
+  
+  private func filePath(of id: UUID) -> URL? {
+    guard var path = FileManager.default.urls(for: .documentDirectory,
+                                              in: .userDomainMask).first else { return nil }
+    let fileName = "\(id.uuidString).jpg"
+    
+    // iOS 16부터 deprecated 되기에 분기처리
+    if #available(iOS 16.0, *) {
+      path.append(path: fileName)
+    } else {
+      path = path.appendingPathComponent(fileName)
+    }
+    return path
+  }
+}


### PR DESCRIPTION
## 이미지 캐싱 구현

### 이미지 로딩 프로세스

1. UUID의 string 으로 Cahche 가져오려고 시도
    1. 있으면 → return
2. 없으면 FileManager 에서 download 하고 return
    1. 하면서 cache에 저장

초기 구현 Image Caching

```swift
final class ImageCacheManager {
  
  // MARK: - Singleton
  static let shared = ImageCacheManager()
  
  private init() { }
  
  // MARK: - Properties
  
  private let cache = NSCache<NSString, UIImage>()
  
  // MARK: - Public Methods
  
  func get(for key: String) -> UIImage? {
    cache.object(forKey: key as NSString)
  }
  
  func store(_ value: UIImage, for key: String) {
    cache.setObject(value, forKey: key as NSString)
  }
  
}
```

> 생각한 문제점: NSCache가 내부적으로 처리를 해주겠지만, 혹시나 캐싱으로 저장되는 이미지가 너무 크거나 저장되는 이미지의 갯수가 너무 많다면?
> 

→ 테스트를 실행… 해본 경로를 적자. 10mb 짜리 이미지도 저장 해 보고, 
이미지 1000개도 저장 해 보자.

### 메모리 용량 제한

이렇게 메모리 totalCostLimit 을 통해 총 저장 용량을 제약을 줄 수 있게끔 구현

```swift
final class ImageCacheManager {
  
  // MARK: - Configuration
  
  private enum Configuration {
    static let countLimit = 100 // 총 100개 까지만 FIFO로 캐싱함
    static let megaByteLimit = 200 * megaByteUnit // 메모리 캐싱에 200메가바이트 만큼 제약을 줌
    static let megaByteUnit = 1024 * 1024
  }
  
  // MARK: - Singleton
  static let shared = ImageCacheManager()
  
  private init() {
    cache.countLimit = Configuration.countLimit
    cache.totalCostLimit = Configuration.megaByteLimit
  }
  
  // MARK: - Properties
  
  private let cache = NSCache<NSString, UIImage>()
  
  // MARK: - Public Methods
  
  func get(for key: String) -> UIImage? {
    cache.object(forKey: key as NSString)
  }
  
  func store(_ value: UIImage, for key: String) {
    let bytesOfImage = value.jpegData(compressionQuality: 1.0)?.count ?? 0
    print("이미지 바이트: ", bytesOfImage)
    cache.setObject(value, forKey: key as NSString, cost: bytesOfImage)
  }
  
}
```

### Thread Safe 할까?

> 출처: 공식문서
> 
- Thread Safe 하다!

You can add, remove, and query items in the cache from different threads without having to lock the cache yourself.

![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/50515986-1706-4049-993d-82065ae58590/Untitled.png)

### 그러다 문득… NSCache 의 내부가 궁금해졌다

> 출처: [https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/NSCache.swift](https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/NSCache.swift)
> 

```swift
open class NSCache<KeyType : AnyObject, ObjectType : AnyObject> : NSObject {
    
    private var _entries = Dictionary<NSCacheKey, NSCacheEntry<KeyType, ObjectType>>()
    private let _lock = NSLock()
    private var _totalCost = 0
    private var _head: NSCacheEntry<KeyType, ObjectType>?
```

! 내부적으로 NSLock을 사용해서 lock, unlock 을 해주기 때문에 thread safe 했던 것

또한 딕셔너리를 사용하지만, 내부의 `_entries` 의 value 인 `NSCacheEntry` 를 살펴보면 prev, next 를 가지는 `linkedList` 형태로 이루어져 있음!

→ countLimit 를 줬을 때, FIFO (선입선출) 로 데이터를 관리하기 위해서 구현해놓은 것을 알 수 있었음!

> 하지만 보장하지는 않는다고 함.
> 

```swift
private class NSCacheEntry<KeyType : AnyObject, ObjectType : AnyObject> {
    var key: KeyType
    var value: ObjectType
    var cost: Int
    var prevByCost: NSCacheEntry?
    var nextByCost: NSCacheEntry?
    init(key: KeyType, value: ObjectType, cost: Int) {
        self.key = key
        self.value = value
        self.cost = cost
    }
}
```

### totalCostLimit

```swift
var purgeAmount = (totalCostLimit > 0) ? (_totalCost - totalCostLimit) : 0
  while purgeAmount > 0 {
    if let entry = _head {
      delegate?.cache(unsafeDowncast(self, to:NSCache<AnyObject, AnyObject>.self), willEvictObject: entry.value)
                
      _totalCost -= entry.cost
      purgeAmount -= entry.cost
                
      remove(entry) // _head will be changed to next entry in remove(_:)
      _entries[NSCacheKey(entry.key)] = nil
    } else {
      break
    }
  }
```

### 캐싱이 지워지는 것에 대한 체크

```swift
extension ImageCacheManager: NSCacheDelegate {
  func cache(_ cache: NSCache<AnyObject, AnyObject>, willEvictObject obj: Any) {
    print("\(obj as? UIImage) 정보가 캐시에서 지워진다.")
  }
}
```

### 딕셔너리와 다르게 키 값을 복사하지 않는다는 말에 대해?

- 이 부분도 의문이 들었지만, 내부 코드를 뜯어보니 조금은 이해되었음.
- 복사하지 않고 참조한다 = 참조 타입만 사용할 수 있다 = AnyObject로 구현해야 한다

```swift
open class NSCache<KeyType : **AnyObject**, ObjectType : AnyObject> : NSObject {
```

```swift
open func setObject(_ obj: ObjectType, forKey key: KeyType, cost g: Int) {
    let g = max(g, 0)
    let **keyRef = NSCacheKey(key)**
```

```swift
fileprivate class NSCacheKey: NSObject {
    var value: AnyObject
    init(_ value: AnyObject) {
        self.value = value
        super.init()
    }
```

- 참조 타입 키값을 wrapping 하는 방식으로 NSCacheKey 로 저장하는 것을 알 수 있었음.

### 결국 내린 결론,

갯수에 대한 제한은 줄 수 있음. 

또한, 저장되는 각 이미지에 용량에 따라 차등적인 CostLimit을 줌으로서 
각 데이터나 총 저장되는 용량에 대한 제한을 간접적으로 줄 수 있음. 

```swift
open var totalCostLimit: Int = 0 // limits are imprecise/not strict
```

주석에 달려있듯이 정확하진 않다고 하긴 하지만, 사용해볼 수 있을 것 같다!

```swift
import UIKit

final class ImageCacheManager {
  
  // MARK: - Configuration
  
  private enum Configuration {
    static let countLimit = 100 // 총 100개 까지만 FIFO로 캐싱함
    static let megaByteLimit = 200 * megaByteUnit // 메모리 캐싱에 200메가바이트 만큼 제약을 줌
    static let megaByteUnit = 1024 * 1024
  }
  
  // MARK: - Singleton
  
  static let shared = ImageCacheManager()
  
  private init() {
    cache.countLimit = Configuration.countLimit
    cache.totalCostLimit = Configuration.megaByteLimit
  }
  
  // MARK: - Properties
  
  private let cache = NSCache<NSString, UIImage>()
  
  // MARK: - Public Methods
  
  func get(for id: UUID) -> UIImage? {
    cache.object(forKey: id.uuidString as NSString)
  }
  
  func store(_ value: UIImage, for id: UUID) {
    let bytesOfImage = value.jpegData(compressionQuality: 1.0)?.count ?? 0
    cache.setObject(value, forKey: id.uuidString as NSString, cost: bytesOfImage)
  }
  
}
```

> 테스트 결과 아쉬운 점은, UIImage 의 실제 이미지 사이즈를 측정하는 것이 쉽지 않았음.
> 
- `jpegData(compressionQuality: 1.0).count` 으로 측정 했는데, jpeg 으로 변환 한 후의 data 사이즈를 측정하는 것이기에 실제 데이터 자체의 용량과는 차이가 있었다.
- 일단은 차후 더 조사 후 개선해 보는 것으로 넘겼음… → KingFisher 같은 라이브러리를 뜯어보는 것도 좋을 듯 했음!

> 주의해야 할 점은, cost를 지정하지 않으면 기본 값은 0 이기 때문에 costLimist 을 걸어주더라도 저장할 때 setObject에서 cost 를 지정하지 않는다면 무한히 캐싱이 저장될 수 있다.
> 
- NSCache는 캐시 히트에 따른 처리까지는 제공하지 않지만, 애초에 디스크 캐싱이 아닌, 메모리 캐싱이기에 더 가벼운 관점으로 접근해도 별 문제 없다고 판단됐음