### PR TITLE
[Feat] 필터 검색 화면 및 기능 구현

### DIFF
--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		B44EA8B92A1B311F008A83FF /* ClothesEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44EA8B82A1B311F008A83FF /* ClothesEntity.swift */; };
 		B44EA8BC2A1B3F72008A83FF /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = B44EA8BB2A1B3F72008A83FF /* Realm */; };
 		B44EA8BE2A1B4AEE008A83FF /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44EA8BD2A1B4AEE008A83FF /* Style.swift */; };
+		B4504B6A2A1DE9EF0018C9BC /* ClothesFilterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4504B692A1DE9EF0018C9BC /* ClothesFilterController.swift */; };
+		B4504B6C2A1DEA310018C9BC /* SortBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4504B6B2A1DEA310018C9BC /* SortBy.swift */; };
+		B4504B6F2A1DEA9A0018C9BC /* FilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4504B6E2A1DEA9A0018C9BC /* FilterCell.swift */; };
 		B46CB8B62A14739F00039F72 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46CB8B52A14739F00039F72 /* AppDelegate.swift */; };
 		B46CB8B82A14739F00039F72 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46CB8B72A14739F00039F72 /* SceneDelegate.swift */; };
 		B46CB8BA2A14739F00039F72 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46CB8B92A14739F00039F72 /* MainTabBarController.swift */; };
@@ -105,6 +108,9 @@
 		B44EA8B62A1B2F6A008A83FF /* ClothesStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesStorage.swift; sourceTree = "<group>"; };
 		B44EA8B82A1B311F008A83FF /* ClothesEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesEntity.swift; sourceTree = "<group>"; };
 		B44EA8BD2A1B4AEE008A83FF /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
+		B4504B692A1DE9EF0018C9BC /* ClothesFilterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesFilterController.swift; sourceTree = "<group>"; };
+		B4504B6B2A1DEA310018C9BC /* SortBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortBy.swift; sourceTree = "<group>"; };
+		B4504B6E2A1DEA9A0018C9BC /* FilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCell.swift; sourceTree = "<group>"; };
 		B46CB8B22A14739F00039F72 /* EasyCloset.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EasyCloset.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B46CB8B52A14739F00039F72 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B46CB8B72A14739F00039F72 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -186,6 +192,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		B4504B6D2A1DEA940018C9BC /* Filter */ = {
+			isa = PBXGroup;
+			children = (
+				B4504B6E2A1DEA9A0018C9BC /* FilterCell.swift */,
+			);
+			path = Filter;
+			sourceTree = "<group>";
+		};
 		B46CB8A92A14739F00039F72 = {
 			isa = PBXGroup;
 			children = (
@@ -256,6 +270,7 @@
 				B4F1F4272A18C84D00DA6358 /* ClothesDetailController.swift */,
 				B438897B2A1493B400476BFC /* HomeController.swift */,
 				B43889792A14935200476BFC /* StyleController.swift */,
+				B4504B692A1DE9EF0018C9BC /* ClothesFilterController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -267,6 +282,7 @@
 				B43889A12A14AD8800476BFC /* Clothes.swift */,
 				B438899F2A14ACF600476BFC /* ClothesCategory.swift */,
 				B4F1F42D2A18D81000DA6358 /* WeatherType.swift */,
+				B4504B6B2A1DEA310018C9BC /* SortBy.swift */,
 				B44EA8BD2A1B4AEE008A83FF /* Style.swift */,
 			);
 			path = Model;
@@ -358,6 +374,7 @@
 		B4D95D492A19E161009C8931 /* Clothes */ = {
 			isa = PBXGroup;
 			children = (
+				B4504B6D2A1DEA940018C9BC /* Filter */,
 				B43889AE2A14C56500476BFC /* CarouselFlowLayout.swift */,
 				B43889B22A150BF500476BFC /* ClothesCarouselCell.swift */,
 				B4470B4F2A1734780024B2B7 /* ClothesCategoryHeaderView.swift */,
@@ -518,6 +535,7 @@
 				B4470B5C2A176C3A0024B2B7 /* ShadowableCellType.swift in Sources */,
 				B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */,
 				B4470B562A1743130024B2B7 /* ClothesList.swift in Sources */,
+				B4504B6F2A1DEA9A0018C9BC /* FilterCell.swift in Sources */,
 				B43889A92A14B7E600476BFC /* ClothesCell.swift in Sources */,
 				B43889A62A14B22100476BFC /* UIViewController+Preview.swift in Sources */,
 				B4F1F4252A18C1FF00DA6358 /* Highlightable.swift in Sources */,
@@ -532,6 +550,7 @@
 				B438897C2A1493B400476BFC /* HomeController.swift in Sources */,
 				B43889A42A14B16D00476BFC /* UIViewPreview.swift in Sources */,
 				B4F1F4282A18C84D00DA6358 /* ClothesDetailController.swift in Sources */,
+				B4504B6C2A1DEA310018C9BC /* SortBy.swift in Sources */,
 				B4E5C56A2A1C9E3E00B14F48 /* UIImage+Resize.swift in Sources */,
 				B44EA8B72A1B2F6A008A83FF /* ClothesStorage.swift in Sources */,
 				B4F1F41B2A17A90F00DA6358 /* InfoView.swift in Sources */,
@@ -545,6 +564,7 @@
 				B438897A2A14935200476BFC /* StyleController.swift in Sources */,
 				B4F1F4362A1914DF00DA6358 /* PhotoPicker.swift in Sources */,
 				B43889A22A14AD8800476BFC /* Clothes.swift in Sources */,
+				B4504B6A2A1DE9EF0018C9BC /* ClothesFilterController.swift in Sources */,
 				B44EA8B92A1B311F008A83FF /* ClothesEntity.swift in Sources */,
 				B46CB8B82A14739F00039F72 /* SceneDelegate.swift in Sources */,
 				B49CAAD12A1B5455008254C7 /* StyleViewModel.swift in Sources */,

--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		B4504B6A2A1DE9EF0018C9BC /* ClothesFilterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4504B692A1DE9EF0018C9BC /* ClothesFilterController.swift */; };
 		B4504B6C2A1DEA310018C9BC /* SortBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4504B6B2A1DEA310018C9BC /* SortBy.swift */; };
 		B4504B6F2A1DEA9A0018C9BC /* FilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4504B6E2A1DEA9A0018C9BC /* FilterCell.swift */; };
+		B4504B762A1DF7030018C9BC /* FilterTitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4504B752A1DF7030018C9BC /* FilterTitleHeaderView.swift */; };
 		B46CB8B62A14739F00039F72 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46CB8B52A14739F00039F72 /* AppDelegate.swift */; };
 		B46CB8B82A14739F00039F72 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46CB8B72A14739F00039F72 /* SceneDelegate.swift */; };
 		B46CB8BA2A14739F00039F72 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46CB8B92A14739F00039F72 /* MainTabBarController.swift */; };
@@ -111,6 +112,7 @@
 		B4504B692A1DE9EF0018C9BC /* ClothesFilterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesFilterController.swift; sourceTree = "<group>"; };
 		B4504B6B2A1DEA310018C9BC /* SortBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortBy.swift; sourceTree = "<group>"; };
 		B4504B6E2A1DEA9A0018C9BC /* FilterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCell.swift; sourceTree = "<group>"; };
+		B4504B752A1DF7030018C9BC /* FilterTitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTitleHeaderView.swift; sourceTree = "<group>"; };
 		B46CB8B22A14739F00039F72 /* EasyCloset.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EasyCloset.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B46CB8B52A14739F00039F72 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B46CB8B72A14739F00039F72 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 			isa = PBXGroup;
 			children = (
 				B4504B6E2A1DEA9A0018C9BC /* FilterCell.swift */,
+				B4504B752A1DF7030018C9BC /* FilterTitleHeaderView.swift */,
 			);
 			path = Filter;
 			sourceTree = "<group>";
@@ -527,6 +530,7 @@
 			files = (
 				B438899E2A14AB8E00476BFC /* UIViewController+NavigationTitle.swift in Sources */,
 				B44EA8BE2A1B4AEE008A83FF /* Style.swift in Sources */,
+				B4504B762A1DF7030018C9BC /* FilterTitleHeaderView.swift in Sources */,
 				B44EA89C2A1B20C7008A83FF /* ClothesDetailViewModel.swift in Sources */,
 				B4470B522A1740AD0024B2B7 /* Array+SafeIndex.swift in Sources */,
 				B43889782A14934600476BFC /* ClothesController.swift in Sources */,

--- a/EasyCloset/EasyCloset/Sources/Model/SortBy.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/SortBy.swift
@@ -1,0 +1,22 @@
+//
+//  SortBy.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/24.
+//
+
+import Foundation
+
+enum SortBy: Int, CaseIterable {
+  case new
+  case old
+  
+  var korean: String {
+    switch self {
+    case .new:
+      return "최신순"
+    case .old:
+      return "오래된순"
+    }
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/View/Clothes/Filter/FilterCell.swift
+++ b/EasyCloset/EasyCloset/Sources/View/Clothes/Filter/FilterCell.swift
@@ -27,6 +27,13 @@ final class FilterCell: UICollectionViewCell {
     fatalError("init(coder:) has not been implemented")
   }
   
+  // MARK: - Lifecycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    filterLabel.text = ""
+  }
+  
   // MARK: - Corner Radius
   // 레이아웃이 변경될 때 마다 모서리를 둥글게 처리해주도록 함
   

--- a/EasyCloset/EasyCloset/Sources/View/Clothes/Filter/FilterCell.swift
+++ b/EasyCloset/EasyCloset/Sources/View/Clothes/Filter/FilterCell.swift
@@ -1,0 +1,68 @@
+//
+//  FilterCell.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/24.
+//
+
+import UIKit
+
+final class FilterCell: UICollectionViewCell {
+  
+  // MARK: - UI Components
+  
+  let filterLabel = UILabel().then {
+    $0.textAlignment = .center
+    $0.font = .pretendardContent
+  }
+  
+  // MARK: - Initialization
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setup()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Corner Radius
+  // 레이아웃이 변경될 때 마다 모서리를 둥글게 처리해주도록 함
+  
+  private var oldFrame: CGRect = .zero
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    guard oldFrame != frame else { return }
+    configureCornerRadius()
+    oldFrame = frame
+  }
+  
+  private func configureCornerRadius() {
+    layer.cornerRadius = frame.height / 2
+  }
+}
+
+// MARK: - UI & Layout
+
+extension FilterCell {
+  
+  private func setup() {
+    setUI()
+    setupLayout()
+  }
+  
+  private func setUI() {
+    layer.borderColor = UIColor.seperator.cgColor
+    layer.borderWidth = 1
+  }
+  
+  private func setupLayout() {
+    addSubview(filterLabel)
+    filterLabel.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/View/Clothes/Filter/FilterTitleHeaderView.swift
+++ b/EasyCloset/EasyCloset/Sources/View/Clothes/Filter/FilterTitleHeaderView.swift
@@ -1,0 +1,64 @@
+//
+//  FilterTitleHeaderView.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/24.
+//
+
+import UIKit
+
+final class FilterTitleHeaderView: UICollectionReusableView {
+  
+  // MARK: - UI Components
+  
+  private let seperatorView = UIView().then {
+    $0.backgroundColor = .seperator
+  }
+  
+  private let filterTitleLabel = UILabel().then {
+    $0.font = .pretendardMediumTitle
+  }
+  
+  // MARK: - Initialization
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupLayout()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Public Methods
+  
+  func configure(with section: ClothesFilterController.Section) {
+    filterTitleLabel.text = section.description
+  }
+  
+  // MARK: - Private Methods
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    filterTitleLabel.text = ""
+  }
+}
+
+// MARK: - Layout
+
+extension FilterTitleHeaderView {
+  
+  private func setupLayout() {
+    addSubview(seperatorView)
+    seperatorView.snp.makeConstraints {
+      $0.top.horizontalEdges.equalToSuperview()
+      $0.height.equalTo(1)
+    }
+    
+    addSubview(filterTitleLabel)
+    filterTitleLabel.snp.makeConstraints {
+      $0.horizontalEdges.equalToSuperview().inset(10)
+      $0.verticalEdges.equalToSuperview()
+    }
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesController.swift
@@ -33,12 +33,13 @@ final class ClothesController: UIViewController {
     $0.itemSize = CGSize(width: view.frame.width, height: Metric.collectionViewRowHeight)
   }
   
-  private let filterButton = UIButton().then {
+  private lazy var filterButton = UIButton().then {
     $0.setImage(.filter, for: .normal)
     $0.imageView?.contentMode = .scaleAspectFit
     $0.snp.makeConstraints { make in
       make.width.height.equalTo(24)
     }
+    $0.addTarget(self, action: #selector(tappedFilterButton), for: .touchUpInside)
   }
     
   // MARK: - Initialization
@@ -63,6 +64,10 @@ final class ClothesController: UIViewController {
   
   // MARK: - Private Methods
   
+  @objc private func tappedFilterButton() {
+    let filterController = ClothesFilterController()
+    present(filterController, animated: true)
+  }
 }
 
 // MARK: - UI & Layout

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesController.swift
@@ -65,7 +65,7 @@ final class ClothesController: UIViewController {
   // MARK: - Private Methods
   
   @objc private func tappedFilterButton() {
-    let filterController = ClothesFilterController()
+    let filterController = ClothesFilterController(viewModel: viewModel)
     present(filterController, animated: true)
   }
 }

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
@@ -43,7 +43,7 @@ final class ClothesFilterController: UIViewController {
   
   private lazy var dataSource: DataSource = makeDataSource()
   
-//  private var selectedItems: [Section: Item] = [:]
+  private var selectedItems: [Section: Item] = [:]
   
   // MARK: - Lifecycle
   
@@ -111,18 +111,19 @@ extension ClothesFilterController: UICollectionViewDelegate {
   
   func collectionView(_ collectionView: UICollectionView,
                       didSelectItemAt indexPath: IndexPath) {
-    guard let section = Section(rawValue: indexPath.section) else { return }
+    guard let section = Section(rawValue: indexPath.section),
+          let item = dataSource.itemIdentifier(for: indexPath) else { return }
     
-    guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
-    switch item {
-    case .sort(let sort):
-      print(sort)
-    case .weather(let weather):
-      print(weather)
-    case .clothes(let clothes):
-      print(clothes)
+    // 이전에 선택된 해당 섹션의 셀이 존재하면 선택 해제
+    if let beforeItem = selectedItems[section],
+       let beforeIndexPath = dataSource.indexPath(for: beforeItem),
+       beforeItem != item {
+      let beforeCell = collectionView.cellForItem(at: beforeIndexPath)
+      beforeCell?.backgroundColor = .white
     }
     
-    collectionView.cellForItem(at: indexPath)?.backgroundColor = .blue
+    // 새롭게 선택된 해당 섹션의 셀을 선택
+    collectionView.cellForItem(at: indexPath)?.backgroundColor = .seperator
+    selectedItems[section] = item
   }
 }

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+typealias FilterItems = [ClothesFilterController.Item]
+
 final class ClothesFilterController: UIViewController {
   
   // MARK: - Types
@@ -91,7 +93,8 @@ final class ClothesFilterController: UIViewController {
   // MARK: - Private Methods
   
   @objc private func tappedDoneButton() {
-    print("완료완료")
+    let filters = selectedItems.values.map { $0 }
+    viewModel.searchWithFilters.send(filters)
   }
   
   private func cofigureDoneButtonActivation() {

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
@@ -1,0 +1,128 @@
+//
+//  ClothesFilterController.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/24.
+//
+
+import UIKit
+
+final class ClothesFilterController: UIViewController {
+  
+  // MARK: - Types
+  
+  typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+  
+  enum Section: Int, CaseIterable {
+    case sort
+    case weather
+    case clothes
+  }
+  
+  enum Item: Hashable {
+    case sort(SortBy)
+    case weather(WeatherType)
+    case clothes(ClothesCategory)
+    
+    var description: String {
+      switch self {
+      case .sort(let sort):
+        return sort.korean
+      case .weather(let weather):
+        return weather.korean
+      case .clothes(let clothes):
+        return clothes.korean
+      }
+    }
+  }
+  
+  // MARK: - Properties
+  
+  private lazy var collectionView = UICollectionView(frame: .zero,
+                                                     collectionViewLayout: makeCollectionViewLayout())
+  
+  private lazy var dataSource: DataSource = makeDataSource()
+  
+//  private var selectedItems: [Section: Item] = [:]
+  
+  // MARK: - Lifecycle
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupCollectionView()
+    applySnapshot()
+  }
+  
+  // MARK: - Private Methods
+  
+  private func setupCollectionView() {
+    view.addSubview(collectionView)
+    collectionView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    collectionView.registerCell(cellClass: FilterCell.self)
+    collectionView.dataSource = dataSource
+    collectionView.delegate = self
+  }
+  
+  private func makeCollectionViewLayout() -> UICollectionViewLayout {
+    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.2),
+                                          heightDimension: .absolute(20))
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+    
+    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                           heightDimension: .estimated(20))
+    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+    
+    let section = NSCollectionLayoutSection(group: group)
+    section.contentInsets = .init(top: 50, leading: 0, bottom: 0, trailing: 0)
+    
+    return UICollectionViewCompositionalLayout(section: section)
+  }
+  
+  private func makeDataSource() -> DataSource {
+    DataSource(collectionView: collectionView) { collectionView, indexPath, item in
+      let cell = collectionView.dequeueReusableCell(cellClass: FilterCell.self, for: indexPath)
+      cell.filterLabel.text = item.description
+      return cell
+    }
+  }
+  
+  private func applySnapshot() {
+    var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+    snapshot.appendSections(Section.allCases)
+    
+    let sortItems = SortBy.allCases.map { Item.sort($0) }
+    let weatherItems = WeatherType.allCases.map { Item.weather($0) }
+    let clothesItems = ClothesCategory.allCases.map { Item.clothes($0) }
+    
+    snapshot.appendItems(sortItems, toSection: .sort)
+    snapshot.appendItems(weatherItems, toSection: .weather)
+    snapshot.appendItems(clothesItems, toSection: .clothes)
+    
+    dataSource.apply(snapshot, animatingDifferences: true)
+  }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension ClothesFilterController: UICollectionViewDelegate {
+  
+  func collectionView(_ collectionView: UICollectionView,
+                      didSelectItemAt indexPath: IndexPath) {
+    guard let section = Section(rawValue: indexPath.section) else { return }
+    
+    guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+    switch item {
+    case .sort(let sort):
+      print(sort)
+    case .weather(let weather):
+      print(weather)
+    case .clothes(let clothes):
+      print(clothes)
+    }
+    
+    collectionView.cellForItem(at: indexPath)?.backgroundColor = .blue
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
@@ -49,31 +49,88 @@ final class ClothesFilterController: UIViewController {
   
   // MARK: - Properties
   
+  private lazy var dataSource: DataSource = makeDataSource()
+  private var selectedItems: [Section: Item] = [:] {
+    didSet {
+      cofigureDoneButtonActivation()
+    }
+  }
+  
+  private let viewModel: ClothesViewModel
+  
+  // MARK: - UI Components
+  
   private lazy var collectionView = UICollectionView(frame: .zero,
                                                      collectionViewLayout: makeCollectionViewLayout())
   
-  private lazy var dataSource: DataSource = makeDataSource()
+  private lazy var doneButton = UIButton().then {
+    $0.setTitle("검색", for: .normal)
+    $0.backgroundColor = .seperator
+    $0.addTarget(self, action: #selector(tappedDoneButton), for: .touchUpInside)
+    $0.isUserInteractionEnabled = false
+  }
   
-  private var selectedItems: [Section: Item] = [:]
+  // MARK: - Initialization
+  
+  init(viewModel: ClothesViewModel) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
   
   // MARK: - Lifecycle
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = .white
-    setupCollectionView()
-    applySnapshot()
+    setup()
   }
   
   // MARK: - Private Methods
   
-  private func setupCollectionView() {
+  @objc private func tappedDoneButton() {
+    print("완료완료")
+  }
+  
+  private func cofigureDoneButtonActivation() {
+    doneButton.isUserInteractionEnabled = selectedItems.isEmpty == false
+    doneButton.backgroundColor = selectedItems.isEmpty ? .seperator : .accentColor
+  }
+}
+
+// MARK: - Layout
+
+extension ClothesFilterController {
+  private func setup() {
+    setupLayout()
+    setupUI()
+    setupCollectionView()
+    applySnapshot()
+  }
+  
+  private func setupLayout() {
     view.addSubview(collectionView)
     collectionView.snp.makeConstraints {
       $0.top.equalToSuperview().inset(30)
-      $0.horizontalEdges.bottom.equalToSuperview()
+      $0.horizontalEdges.equalToSuperview()
     }
     
+    view.addSubview(doneButton)
+    doneButton.snp.makeConstraints {
+      $0.horizontalEdges.bottom.equalToSuperview().inset(40)
+      $0.top.equalTo(collectionView.snp.bottom)
+      $0.height.equalTo(50)
+    }
+  }
+  
+  private func setupUI() {
+    view.backgroundColor = .white
+    doneButton.layer.cornerRadius = 8
+  }
+  
+  private func setupCollectionView() {
     collectionView.registerCell(cellClass: FilterCell.self)
     collectionView.registerHeaderView(viewClass: FilterTitleHeaderView.self)
     collectionView.dataSource = dataSource
@@ -91,7 +148,7 @@ final class ClothesFilterController: UIViewController {
     let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                            heightDimension: .estimated(20))
     let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-
+    
     let section = NSCollectionLayoutSection(group: group)
     section.contentInsets = .init(top: 8, leading: 10, bottom: 16, trailing: 10)
     
@@ -108,6 +165,11 @@ final class ClothesFilterController: UIViewController {
       elementKind: UICollectionView.elementKindSectionHeader,
       alignment: .top)
   }
+}
+
+// MARK: - DataSource
+
+extension ClothesFilterController {
   
   private func makeDataSource() -> DataSource {
     DataSource(collectionView: collectionView) { collectionView, indexPath, item in
@@ -180,7 +242,7 @@ import SwiftUI
 
 struct ClothesFilterControllerPreview: PreviewProvider {
   static var previews: some View {
-    return ClothesFilterController().toPreview()
+    return ClothesFilterController(viewModel: ClothesViewModel()).toPreview()
   }
 }
 #endif

--- a/EasyCloset/EasyCloset/Sources/ViewModel/ClothesViewModel.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewModel/ClothesViewModel.swift
@@ -15,7 +15,7 @@ final class ClothesViewModel {
   
   @Published private var clothesList = ClothesList(clothesByCategory: [:])
   
-  let searchWithFilters = CurrentValueSubject<FilterItems, Never>([])
+  let searchFilters = CurrentValueSubject<FilterItems, Never>([])
   let clothesListDidUpdate = PassthroughSubject<Void, Never>()
   
   private var cancellables = Set<AnyCancellable>()
@@ -38,7 +38,7 @@ final class ClothesViewModel {
   func clothes(of category: ClothesCategory) -> AnyPublisher<[Clothes], Never> {
     $clothesList
       .map { $0.clothesByCategory[category] ?? [] }
-      .combineLatest(searchWithFilters)
+      .combineLatest(searchFilters)
       .map(applyFilters)
       .eraseToAnyPublisher()
   }
@@ -71,20 +71,6 @@ final class ClothesViewModel {
         return applyClothes(filter: clothes, to: currentList)
       }
     }
-    
-//    var filteredClothes = clothesList
-//    
-//    for filter in filters {
-//      switch filter {
-//      case .sort(let sort):
-//        filteredClothes = applySort(filter: sort, to: filteredClothes)
-//      case .weather(let weather):
-//        filteredClothes = applyWeather(filter: weather, to: filteredClothes)
-//      case .clothes(let clothes):
-//        filteredClothes = applyClothes(filter: clothes, to: filteredClothes)
-//      }
-//    }
-//    return filteredClothes
   }
   
   private func applySort(filter: SortBy, to clothesList: [Clothes]) -> [Clothes] {

--- a/EasyCloset/EasyCloset/Sources/ViewModel/ClothesViewModel.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewModel/ClothesViewModel.swift
@@ -13,8 +13,9 @@ final class ClothesViewModel {
   
   // MARK: - Properties
   
-  @Published private(set) var clothesList = ClothesList(clothesByCategory: [:])
+  @Published private var clothesList = ClothesList(clothesByCategory: [:])
   
+  let searchWithFilters = CurrentValueSubject<FilterItems, Never>([])
   let clothesListDidUpdate = PassthroughSubject<Void, Never>()
   
   private var cancellables = Set<AnyCancellable>()
@@ -36,9 +37,9 @@ final class ClothesViewModel {
   
   func clothes(of category: ClothesCategory) -> AnyPublisher<[Clothes], Never> {
     $clothesList
-      .map {
-        $0.clothesByCategory[category] ?? []
-      }
+      .map { $0.clothesByCategory[category] ?? [] }
+      .combineLatest(searchWithFilters)
+      .map(applyFilters)
       .eraseToAnyPublisher()
   }
   
@@ -57,5 +58,49 @@ final class ClothesViewModel {
         self?.clothesList = clothesList
       }
       .store(in: &cancellables)
+  }
+    
+  private func applyFilters(clothesList: [Clothes], filters: FilterItems) -> [Clothes] {
+    return filters.reduce(clothesList) { currentList, filter in
+      switch filter {
+      case .sort(let sort):
+        return applySort(filter: sort, to: currentList)
+      case .weather(let weather):
+        return applyWeather(filter: weather, to: currentList)
+      case .clothes(let clothes):
+        return applyClothes(filter: clothes, to: currentList)
+      }
+    }
+    
+//    var filteredClothes = clothesList
+//    
+//    for filter in filters {
+//      switch filter {
+//      case .sort(let sort):
+//        filteredClothes = applySort(filter: sort, to: filteredClothes)
+//      case .weather(let weather):
+//        filteredClothes = applyWeather(filter: weather, to: filteredClothes)
+//      case .clothes(let clothes):
+//        filteredClothes = applyClothes(filter: clothes, to: filteredClothes)
+//      }
+//    }
+//    return filteredClothes
+  }
+  
+  private func applySort(filter: SortBy, to clothesList: [Clothes]) -> [Clothes] {
+    switch filter {
+    case .new:
+      return clothesList.sorted { $0.createdAt > $1.createdAt }
+    case .old:
+      return clothesList.sorted { $0.createdAt < $1.createdAt }
+    }
+  }
+  
+  private func applyWeather(filter: WeatherType, to clothesList: [Clothes]) -> [Clothes] {
+    return clothesList.filter { $0.weatherType == filter }
+  }
+  
+  private func applyClothes(filter: ClothesCategory, to clothesList: [Clothes]) -> [Clothes] {
+    return clothesList.filter { $0.category == filter }
   }
 }


### PR DESCRIPTION
## 필터링 로직 바인딩 구현
- 기존에 사용하던 ClothesViewModel을 재사용하여 자식컨트롤러인 FilterController에게 주입하는 방식으로 사용
  > 필터링 기능 자체가, 기존의 ClothesList를 필터링 하는 로직이기에 같은 데이터를 참조하는 것이 적절해보였음
- 필터링 로직도 함수형 프로그래밍 패러다임의 순수함수적으로 구현하면 좋겠다고 생각함. 
- 원본의 ClothesList 데이터를 수정하지 않고 필터를 적용시켜서 필터가 적용된 값들을 반환하는 함수를 만들어서
-  observing 을 할 때, 필터링이 적용된 값을 반환하도록 함

```swift
@Published private var clothesList = ClothesList(clothesByCategory: [:])

  // 옷 리스트인 원본 데이터를 손상하지 않고, 특정 옷을 바인딩하기 위해 접근 할 때 필터링
  func clothes(of category: ClothesCategory) -> AnyPublisher<[Clothes], Never> {
    $clothesList
      // 바인딩 하고자 하는 옷들만 뽑고
      .map { $0.clothesByCategory[category] ?? [] }
      // 필터를 함께 CombineLatest한 뒤,
      .combineLatest(searchFilters)
      // filter를 적용함
      .map(applyFilters)
      .eraseToAnyPublisher()
  }

  // 필터링을 적용하는 로직 구현
  private func applyFilters(clothesList: [Clothes], filters: FilterItems) -> [Clothes] {
      return filters.reduce(clothesList) { currentList, filter in
        switch filter {
        case .sort(let sort):
          return applySort(filter: sort, to: currentList)
        case .weather(let weather):
          return applyWeather(filter: weather, to: currentList)
        case .clothes(let clothes):
          return applyClothes(filter: clothes, to: currentList)
        }
      }
    }
  
  // 각각의 필터를 적용하는 로직 구현
    private func applySort(filter: SortBy, to clothesList: [Clothes]) -> [Clothes] {
      switch filter {
      case .new:
        return clothesList.sorted { $0.createdAt > $1.createdAt }
      case .old:
        return clothesList.sorted { $0.createdAt < $1.createdAt }
      }
    }
  
  private func applyWeather(filter: WeatherType, to clothesList: [Clothes]) -> [Clothes] {
    return clothesList.filter { $0.weatherType == filter }
  }
  
  private func applyClothes(filter: ClothesCategory, to clothesList: [Clothes]) -> [Clothes] {
    return clothesList.filter { $0.category == filter }
  }
```

### searchFilters에 CurrentValueSubject 를 사용한 이유
- 유저가 한 번 필터를 적용하고 나면, 해당 필터에 대한 정보를 계속 유지한 채로 들고 있다가 다시 필터 화면으로 들어갔을 때 해당 필터 정보들을 보여줘야 했음
- 그렇기에 사용자가 마지막으로 send 한 값을 유지하는 CurrentValueSubject로 구현함.
- 반면에, clothesListDidUpdate 와 같은 특정 이벤트를 뷰모델에 알리기 위한 바인딩 property는 PassthroughSubject로 구현함. (아니면 sink (subscribe) 할 때 마다 매번 마지막으로 보낸 값이 전달되기 때문에)