### PR TITLE
[Refactor] File Manager의 파일 입출력 Combine 으로 비동기 처리

### DIFF
--- a/EasyCloset/EasyCloset/Sources/Data/Storage/ClothesStorage.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Storage/ClothesStorage.swift
@@ -35,7 +35,13 @@ struct ClothesStorage: ClothesStorageProtocol {
     return realm.objects(ClothesEntity.self)
       .map { entity in
         var model = entity.toModelWithoutImage()
-        model.image = ImageFileStorage.shared.load(withID: model.id)
+        
+        // TODO: 얘가 비동기이기 때문에 이미지가 로드되기도 전에 기다리지 않고 넘어감. 또한 함수형으로 처리하기 힘들어짐... completion 내부로 처리해야 함..!
+        ImageFileStorage.shared.load(withID: model.id) { image in
+          if let image = image {
+            model.image = image
+          }
+        }
         return model
       }
       .reduce(into: ClothesList(clothesByCategory: [:]), { result, clothes in

--- a/EasyCloset/EasyCloset/Sources/Data/Storage/ClothesStorage.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Storage/ClothesStorage.swift
@@ -49,7 +49,7 @@ final class ClothesStorage: ClothesStorageProtocol {
       let clothesEntities = Array(realm.objects(ClothesEntity.self))
       let clothesModelsWithoutImage = clothesEntities.map { $0.toModelWithoutImage() }
       
-      addingImagePublishers(to: clothesModelsWithoutImage)
+      addingImages(to: clothesModelsWithoutImage)
         .sink { clothesModels in
           // 이미지가 모두 반영 된 ClothesList
           let clothesList = clothesModels.toClothesList()
@@ -81,7 +81,7 @@ final class ClothesStorage: ClothesStorageProtocol {
   
   // MARK: - Private Methods
   
-  private func addingImagePublishers(to clothesModels: [Clothes]) -> AnyPublisher<[Clothes], Never> {
+  private func addingImages(to clothesModels: [Clothes]) -> AnyPublisher<[Clothes], Never> {
     // ImageFileStorage를 호출해 이미지를 로딩해서 clothes에 넣는 것을 처리하는 Publisher들
     let clothesWithImagePublishers: [AnyPublisher<Clothes, Never>] = clothesModels.map { model in
       ImageFileStorage.shared.load(withID: model.id)

--- a/EasyCloset/EasyCloset/Sources/Data/Storage/ClothesStorage.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Storage/ClothesStorage.swift
@@ -11,7 +11,7 @@ import RealmSwift
 import Then
 
 protocol ClothesStorageProtocol {
-  func fetchClothesList() -> ClothesList?
+  func fetchClothesList(completion: @escaping (ClothesList?) -> Void)
   func save(clothes: Clothes)
   func removeAll()
 }
@@ -29,25 +29,59 @@ struct ClothesStorage: ClothesStorageProtocol {
   
   // MARK: - Public Methods
   
-  func fetchClothesList() -> ClothesList? {
-    guard let realm = realm else { return nil }
+  func fetchClothesList(completion: @escaping (ClothesList?) -> Void) {
+    guard let realm = realm else {
+      completion(nil)
+      return
+    }
     
-    return realm.objects(ClothesEntity.self)
-      .map { entity in
-        var model = entity.toModelWithoutImage()
-        
-        // TODO: 얘가 비동기이기 때문에 이미지가 로드되기도 전에 기다리지 않고 넘어감. 또한 함수형으로 처리하기 힘들어짐... completion 내부로 처리해야 함..!
-        ImageFileStorage.shared.load(withID: model.id) { image in
-          if let image = image {
-            model.image = image
-          }
+    let clothesEntities = realm.objects(ClothesEntity.self)
+    var clothesList = ClothesList(clothesByCategory: [:])
+    
+    let dispatchGroup = DispatchGroup()
+    let serialQueue = DispatchQueue(label: "serialQueue")
+    
+    clothesEntities.forEach { entity in
+      var model = entity.toModelWithoutImage()
+      
+      dispatchGroup.enter()
+      
+      ImageFileStorage.shared.load(withID: model.id) { image in
+        if let image = image {
+          model.image = image
         }
-        return model
+        // 딕셔너리에 동시 접근 때문에 발생하는 문제를 serialQueue로 방지
+        serialQueue.async {
+          clothesList.clothesByCategory[model.category, default: []].append(model)
+        }
+        dispatchGroup.leave()
       }
-      .reduce(into: ClothesList(clothesByCategory: [:]), { result, clothes in
-        result.clothesByCategory[clothes.category, default: []].append(clothes)
-      })
+    }
+    
+    dispatchGroup.notify(queue: .main) {
+      completion(clothesList)
+    }
   }
+  
+//  func fetchClothesList() -> ClothesList? {
+//    guard let realm = realm else { return nil }
+//
+//    return realm.objects(ClothesEntity.self)
+//      .map { entity in
+//        var model = entity.toModelWithoutImage()
+//
+//        // TODO: 얘가 비동기이기 때문에 이미지가 로드되기도 전에 기다리지 않고 넘어감. 또한 함수형으로 처리하기 힘들어짐... completion 내부로 처리해야 함..!
+//        ImageFileStorage.shared.load(withID: model.id) { image in
+//          if let image = image {
+//            model.image = image
+//          }
+//        }
+//        return model
+//      }
+//      .reduce(into: ClothesList(clothesByCategory: [:]), { result, clothes in
+//        result.clothesByCategory[clothes.category, default: []].append(clothes)
+//      })
+//  }
   
   func save(clothes: Clothes) {
     guard let realm = realm else { return }

--- a/EasyCloset/EasyCloset/Sources/Data/Storage/ClothesStorage.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Storage/ClothesStorage.swift
@@ -13,6 +13,7 @@ import Then
 protocol ClothesStorageProtocol {
   func fetchClothesList() -> ClothesList?
   func save(clothes: Clothes)
+  func removeAll()
 }
 
 struct ClothesStorage: ClothesStorageProtocol {
@@ -44,10 +45,6 @@ struct ClothesStorage: ClothesStorageProtocol {
   
   func save(clothes: Clothes) {
     guard let realm = realm else { return }
-    
-    let clothesList = realm.objects(ClothesEntity.self)
-    
-    let idString = clothes.id.uuidString
     
     let clothesEntity = clothes.toEntity()
     

--- a/EasyCloset/EasyCloset/Sources/Data/Storage/ImageFileStorage.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Storage/ImageFileStorage.swift
@@ -11,7 +11,7 @@ import Combine
 
 protocol ImageFileStorageProtocol {
   func save(image: UIImage, id: UUID, completion: ((FileManagerError?) -> Void)?)
-  func load(withID id: UUID, completion: @escaping (UIImage?) -> Void)
+  func load(withID id: UUID) -> Future<UIImage, FileManagerError>
   func remove(withID id: UUID, completion: ((FileManagerError?) -> Void)?)
 }
 
@@ -41,23 +41,6 @@ final class ImageFileStorage: ImageFileStorageProtocol {
         completion?(nil)
       } catch {
         completion?(.failToWrite(error: error))
-      }
-    }
-  }
-  
-  func load(withID id: UUID, completion: @escaping (UIImage?) -> Void) {
-    guard let filePath = filePath(of: id) else {
-      completion(nil)
-      return
-    }
-    
-    DispatchQueue.global().async {
-      do {
-        let data = try Data(contentsOf: filePath)
-        let image = UIImage(data: data)
-        completion(image)
-      } catch {
-        completion(nil)
       }
     }
   }

--- a/EasyCloset/EasyCloset/Sources/Data/Storage/ImageFileStorage.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Storage/ImageFileStorage.swift
@@ -62,6 +62,28 @@ final class ImageFileStorage: ImageFileStorageProtocol {
     }
   }
   
+  func load(withID id: UUID) -> Future<UIImage, FileManagerError> {
+    return Future { promise in
+      guard let filePath = self.filePath(of: id) else {
+        promise(.failure(.invalidFilePath))
+        return
+      }
+      
+      DispatchQueue.global().async {
+        do {
+          let data = try Data(contentsOf: filePath)
+          guard let image = UIImage(data: data) else {
+            promise(.failure(.invalidData))
+            return
+          }
+          promise(.success(image))
+        } catch {
+          promise(.failure(.failToWrite(error: error)))
+        }
+      }
+    }
+  }
+  
   func remove(withID id: UUID, completion: ((FileManagerError?) -> Void)? = nil) {
     guard let filePath = filePath(of: id) else {
       completion?(.invalidFilePath)

--- a/EasyCloset/EasyCloset/Sources/Model/Clothes.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/Clothes.swift
@@ -30,6 +30,16 @@ struct Clothes: Hashable {
   }
 }
 
+// MARK: - [Clothes] 를 ClothesList 타입으로 변환
+// Why: dictionary 의 key값으로 category를 매칭시켜 각 옷 종류에 따른 옷들에 접근 시 O(1)으로 접근하게 하기 위함
+extension Array where Element == Clothes {
+  func toClothesList() -> ClothesList {
+    return reduce(into: ClothesList(clothesByCategory: [:]), { result, clothes in
+      result.clothesByCategory[clothes.category, default: []].append(clothes)
+    })
+  }
+}
+
 // MARK: - Entity Mapping
 
 extension Clothes {

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesDetailController.swift
@@ -97,20 +97,26 @@ final class ClothesDetailController: UIViewController {
       .sink { [weak self] clothes in
         guard let self = self,
               let clothes = clothes else { return }
-        self.configure(with: clothes)
+        DispatchQueue.main.async {
+          self.configure(with: clothes)
+        }
       }
       .store(in: &cancellables)
     
     viewModel.didFailToSave
       .sink { [weak self] message in
-        self?.showFailAlert(with: message)
+        DispatchQueue.main.async {
+          self?.showFailAlert(with: message)
+        }
       }
       .store(in: &cancellables)
     
     viewModel.didSuccessToSave
       .sink { [weak self] in
         if case .add = self?.type {
-          self?.navigationController?.popViewController(animated: true)
+          DispatchQueue.main.async {
+            self?.navigationController?.popViewController(animated: true)
+          }
         }
       }
       .store(in: &cancellables)

--- a/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/ClothesFilterController.swift
@@ -103,7 +103,6 @@ final class ClothesFilterController: UIViewController {
   
   private func setSelectedFilters(with filters: FilterItems) {
     filters.forEach { filter in
-      print(filter)
       switch filter {
       case .sort:
         self.selectedItems[.sort] = filter

--- a/EasyCloset/EasyCloset/Sources/ViewModel/ClothesDetailViewModel.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewModel/ClothesDetailViewModel.swift
@@ -39,6 +39,8 @@ final class ClothesDetailViewModel {
       guard let self = self,
             let clothes = clothes else { return }
       
+      // TODO: 뷰모델에서 너무 많은 일을 함...
+      
       clothesStorage.save(clothes: clothes)
       
       guard let image = clothes.image else {
@@ -46,13 +48,13 @@ final class ClothesDetailViewModel {
         return
       }
       
-      do {
-        try imageFileStorage.save(image: image, id: clothes.id)
-      } catch {
-        didFailToSave.send("저장에 실패했습니다.")
+      imageFileStorage.save(image: image, id: clothes.id) { [weak self] error in
+        guard error == nil else {
+          self?.didFailToSave.send("저장에 실패했습니다.")
+          return
+        }
+        self?.didSuccessToSave.send()
       }
-      
-      didSuccessToSave.send()
     }
     .store(in: &cancellables)
   }

--- a/EasyCloset/EasyCloset/Sources/ViewModel/ClothesDetailViewModel.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewModel/ClothesDetailViewModel.swift
@@ -40,7 +40,7 @@ final class ClothesDetailViewModel {
             let clothes = clothes else { return }
       
       // TODO: 뷰모델에서 너무 많은 일을 함...
-      
+      // -> ClothesRepository에 저장하는 것으로 추상화하고, Repository 내부에서 Image저장 등을 알아서 처리하도록 해야 할 듯
       clothesStorage.save(clothes: clothes)
       
       guard let image = clothes.image else {
@@ -48,13 +48,17 @@ final class ClothesDetailViewModel {
         return
       }
       
-      imageFileStorage.save(image: image, id: clothes.id) { [weak self] error in
-        guard error == nil else {
-          self?.didFailToSave.send("저장에 실패했습니다.")
-          return
-        }
-        self?.didSuccessToSave.send()
-      }
+      imageFileStorage.save(image: image, id: clothes.id)
+        .print("스토리지지이이지")
+        .sink(receiveCompletion: { [weak self] completion in
+          switch completion {
+          case .finished:
+            self?.didSuccessToSave.send()
+          case .failure:
+            self?.didFailToSave.send("저장에 실패했습니다.")
+          }
+        }, receiveValue: {}) // Future<Void, Never> 이므로 따로 처리 X
+        .store(in: &cancellables)
     }
     .store(in: &cancellables)
   }

--- a/EasyCloset/EasyCloset/Sources/ViewModel/ClothesViewModel.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewModel/ClothesViewModel.swift
@@ -46,18 +46,33 @@ final class ClothesViewModel {
   // MARK: - Private Methods
   
   private func bind() {
-    if let fetchedClothesList = clothesStorage.fetchClothesList() {
-      self.clothesList = fetchedClothesList
+    clothesStorage.fetchClothesList { clothesList in
+      if let clothesList = clothesList {
+        self.clothesList = clothesList
+      }
     }
+//    if let fetchedClothesList = clothesStorage.fetchClothesList() {
+//      self.clothesList = fetchedClothesList
+//    }
     
     clothesListDidUpdate
-      .compactMap { [weak self] in
-        self?.clothesStorage.fetchClothesList()
-      }
-      .sink { [weak self] clothesList in
-        self?.clothesList = clothesList
+      .sink { [weak self] in
+        self?.clothesStorage.fetchClothesList { clothesList in
+          if let clothesList = clothesList {
+            self?.clothesList = clothesList
+          }
+        }
       }
       .store(in: &cancellables)
+    
+//    clothesListDidUpdate
+//      .compactMap { [weak self] in
+//        self?.clothesStorage.fetchClothesList()
+//      }
+//      .sink { [weak self] clothesList in
+//        self?.clothesList = clothesList
+//      }
+//      .store(in: &cancellables)
   }
     
   private func applyFilters(clothesList: [Clothes], filters: FilterItems) -> [Clothes] {


### PR DESCRIPTION
## FileManager 를 비동기적으로 처리

- 이전의 코드 → FileManger 를 통해 이미지를 가져올 때 파일 입출력을 main Thread 에서 그냥 돌리고 있어서 이미지가 크거나, 여러 요청이 동시 다발적으로 들어오게 되면 경우에는 문제가 발생할 수 있을 것이라 판단

```swift
func save(image: UIImage, id: UUID) throws {
	guard let data = image.pngData(),
        let filePath = filePath(of: id) else { return }
	try data.write(to: filePath)
}

func load(withID id: UUID) -> UIImage? {
  guard let filePath = filePath(of: id) else { return nil }
  do {
    let data = try Data(contentsOf: filePath)
    return UIImage(data: data)
  } catch {
    return nil
  }
}

@discardableResult
func remove(withID id: UUID) -> Bool {
  guard let filePath = filePath(of: id) else { return false }
  
  do {
    try FileManager.default.removeItem(at: filePath)
    return true
  } catch {
    return false
	}
}
```

### Completion Handler 방식으로 변경
그래서 이렇게 DispatchQueue의 global() 큐를 통해 백그라운드 스레드에서 돌리고, 결과값을 completion Handler 에서 처리하게끔 변경함

```swift
func save(image: UIImage, id: UUID, completion: ((FileManagerError?) -> Void)? = nil) {
    guard let data = image.pngData(),
          let filePath = filePath(of: id) else { return }
    
    DispatchQueue.global(qos: .utility).async {
      do {
        try data.write(to: filePath)
        completion?(nil)
      } catch {
        completion?(.failToWrite(error: error))
      }
    }
  }
  
  func load(withID id: UUID, completion: @escaping (UIImage?) -> Void) {
    guard let filePath = filePath(of: id) else {
      completion(nil)
      return
    }
    
    DispatchQueue.global().async {
      do {
        let data = try Data(contentsOf: filePath)
        let image = UIImage(data: data)
        completion(image)
      } catch {
        completion(nil)
      }
    }
  }
  
  func remove(withID id: UUID, completion: ((FileManagerError?) -> Void)? = nil) {
    guard let filePath = filePath(of: id) else {
      completion?(.invalidFilePath)
      return
    }
    
    DispatchQueue.global(qos: .utility).async {
      do {
        try FileManager.default.removeItem(at: filePath)
        completion?(nil)
      } catch {
        completion?(.failToWrite(error: error))
      }
    }
```

- 그러나 이렇게 활용한다면… fetchClothesList 를 하는 곳에서도 복잡하게 비동기 처리를 해주고, 로딩이 다 완료되었을 때 completion 처리를 하기 위해서 아래같이 복잡하게 로직을 작성해야 했음ㅠ
> DispatchGroup을 이용해서, 모든 비동기 작업이 완료되었을 때 completion을 호출하도록 처리.
> 
- 이렇게 했을 때는 기존의 ViewModel 에서 사용자 입력 이벤트에 대해 Combine으로 바인딩 한 부분과도 잘 맞지 않고, 
코드가 직관적이지 않아지는 단점이 발생함.
> Combine으로 리팩터링 해보기로 결정

```swift
func fetchClothesList(completion: @escaping (ClothesList?) -> Void) {
    guard let realm = realm else {
      completion(nil)
      return
    }
    
    let clothesEntities = realm.objects(ClothesEntity.self)
    var clothesList = ClothesList(clothesByCategory: [:])
    
    let dispatchGroup = DispatchGroup()
    let serialQueue = DispatchQueue(label: "serialQueue")
    
    clothesEntities.forEach { entity in
      var model = entity.toModelWithoutImage()
      
      dispatchGroup.enter()
      
      ImageFileStorage.shared.load(withID: model.id) { image in
        if let image = image {
          model.image = image
        }
        // 딕셔너리에 동시 접근 때문에 발생하는 문제를 serialQueue로 방지
        serialQueue.async {
          clothesList.clothesByCategory[model.category, default: []].append(model)
        }
        dispatchGroup.leave()
      }
    }
    
    dispatchGroup.notify(queue: .main) {
      completion(clothesList)
    }
  }
```

### Combine 으로 리팩터링

> Future를 사용한 이유: 한 번 값을 밷고 바로 종료되는 것이 적합한 동작이라 판단했기 때문에!
공식문서: `A publisher that eventually produces a single value and then finishes or fails.`

```swift
// ImageFileManager 의 이미지를 로딩하는 부분을 Combine으로 리팩터링
func load(withID id: UUID) -> Future<UIImage, FileManagerError> {
  return Future { promise in
    guard let filePath = self.filePath(of: id) else {
      promise(.failure(.invalidFilePath))
      return
    }
    
    DispatchQueue.global().async {
      do {
        let data = try Data(contentsOf: filePath)
        guard let image = UIImage(data: data) else {
          promise(.failure(.invalidData))
          return
        }
        promise(.success(image))
      } catch {
        promise(.failure(.failToWrite(error: error)))
      }
    }
  }
}
```

ClothesStorage 또한 realm 에서 먼저 entity 를 로딩하여 model 로 매핑 한 후,
ImageFileManager에서 이미지를 로딩하여 넣어주고 반환하는데 
해당 로직을 Combine으로 리팩터링 함

```swift
// ClothesStorage에서 리스트를 받아오는 부분
func fetchClothesList() -> AnyPublisher<ClothesList, StorageError> {
  return Future { [weak self] promise in
    guard let self = self else { return }
    
    guard let realm = self.realm else {
      promise(.failure(.realmNotInitialized))
      return
    }
    
    // 반영한 모델들을 다 합한 결과를 future로 내뱉음.
    let clothesEntities = realm.objects(ClothesEntity.self)
    var clothesList = ClothesList(clothesByCategory: [:])
    let clothesModelsWithoutImage = clothesEntities.map { $0.toModelWithoutImage() }
    
    // ImageFileStorage를 호출해 이미지를 로딩해서 clothes에 넣는 것을 처리하는 Publisher들
    let clothesWithImagePublishers: [AnyPublisher<Clothes, Never>] = clothesModelsWithoutImage.map { model in
      ImageFileStorage.shared.load(withID: model.id)
        .replaceError(with: UIImage())
        .map { image in
          var clothes = model
          clothes.image = image
          return clothes
        }
        .eraseToAnyPublisher()
    }
    
    // 위에서 만든 단일의 Clothes를 방출하는 여러 Publisher들을 모아서 [Clothes] 를 방출하는 하나의 Publisher로 만듬
    Publishers.MergeMany(clothesWithImagePublishers)
      .collect()
      .eraseToAnyPublisher()
      .sink { clothesArray in
        // 이미지가 모두 반영 된 ClothesList
        let clothesList = clothesArray.toClothesList()
        promise(.success(clothesList))
      }
      .store(in: &cancellables)
  }
  .eraseToAnyPublisher()
}
```

### 메서드 분리
> ClothesStorage 내부의 combine 결합 로직이 커져서 메서드로 분리함

```swift
func fetchClothesList() -> AnyPublisher<ClothesList, StorageError> {
  return Future { [weak self] promise in
    guard let self = self else { return }
    
    guard let realm = realm else {
      promise(.failure(.realmNotInitialized))
      return
    }
    
    // 반영한 모델들을 다 합한 결과를 future로 내뱉음.
    let clothesEntities = Array(realm.objects(ClothesEntity.self))
    let clothesModelsWithoutImage = clothesEntities.map { $0.toModelWithoutImage() }
    
    addingImagePublishers(to: clothesModelsWithoutImage)
      .sink { clothesModels in
        // 이미지가 모두 반영 된 ClothesList
        let clothesList = clothesModels.toClothesList()
        promise(.success(clothesList))
      }
      .store(in: &cancellables)
  }
  .eraseToAnyPublisher()
}

private func addingImagePublishers(to clothesModels: [Clothes]) -> AnyPublisher<[Clothes], Never> {
  // ImageFileStorage를 호출해 이미지를 로딩해서 clothes에 넣는 것을 처리하는 Publisher들
  let clothesWithImagePublishers: [AnyPublisher<Clothes, Never>] = clothesModels.map { model in
    ImageFileStorage.shared.load(withID: model.id)
      .replaceError(with: UIImage())
      .map { image in
        var clothes = model
        clothes.image = image
        return clothes
      }
      .eraseToAnyPublisher()
  }
  
  // 위에서 만든 단일의 Clothes를 방출하는 여러 Publisher들을 모아서 [Clothes] 를 방출하는 하나의 Publisher로 만듬
  return Publishers.MergeMany(clothesWithImagePublishers)
    .collect()
    .eraseToAnyPublisher()
}
```

## 그렇다면 Realm 은 thread safe 할까?

![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/7f1d2d7e-4ce6-4337-8e8c-854ae78fbfa3/Untitled.png)

- Realm 데이터베이스는 MVCC(Multiversion Concurrency Control) 아키텍처를 사용하므로 읽기 작업을 위한 lock 이 필요 없다.
- 안정성을 위해, 하나의 스레드에서 작업하도록 설계되어 있기에 
다른 스레드에서 Realm 객체를 사용하면 충돌이 일어난다!
- 그렇기에 엄청나게 많은 데이터를 읽고 쓴다면 메인 스레드가 block 될 수 있음 
→ 필요하다면 `ThreadSafeReference` 를 통해 다른 스레드에서 사용할 수 있게 Realm 객체를 전달해서 사용해야 한다!
    
    > 아직은 당장 필요한 구현이 아니라고 판단함.
    > 
    
    [Class ThreadSafeReference    | Realm](https://www.mongodb.com/docs/legacy/realm/dotnet/5.1.0/api/reference/Realms.ThreadSafeReference.html)