### PR TITLE
[Feat] Style Repository 구현, ✨ Repository Protoco분리(ImageFetchable), POP 구현

### DIFF
--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -63,6 +63,10 @@
 		B49CAAD52A1B8AD6008254C7 /* UIImage+Collage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */; };
 		B4B456812A1F9A67003354F8 /* StyleAddClothesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B456802A1F9A66003354F8 /* StyleAddClothesController.swift */; };
 		B4C4E7C62A20526C000859DD /* StyleAddClothesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7C52A20526C000859DD /* StyleAddClothesCell.swift */; };
+		B4C4E7C82A2077C7000859DD /* StyleEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7C72A2077C7000859DD /* StyleEntity.swift */; };
+		B4C4E7CA2A207A03000859DD /* StyleRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7C92A207A03000859DD /* StyleRepository.swift */; };
+		B4C4E7CC2A208379000859DD /* ImageFetchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7CB2A208379000859DD /* ImageFetchable.swift */; };
+		B4C4E7D02A2087A2000859DD /* ImagableModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7CF2A2087A2000859DD /* ImagableModel.swift */; };
 		B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */; };
 		B4E5C56A2A1C9E3E00B14F48 /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */; };
 		B4E5C56C2A1CAC0C00B14F48 /* ImageFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5C56B2A1CAC0C00B14F48 /* ImageFileStorage.swift */; };
@@ -133,6 +137,10 @@
 		B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Collage.swift"; sourceTree = "<group>"; };
 		B4B456802A1F9A66003354F8 /* StyleAddClothesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleAddClothesController.swift; sourceTree = "<group>"; };
 		B4C4E7C52A20526C000859DD /* StyleAddClothesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleAddClothesCell.swift; sourceTree = "<group>"; };
+		B4C4E7C72A2077C7000859DD /* StyleEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleEntity.swift; sourceTree = "<group>"; };
+		B4C4E7C92A207A03000859DD /* StyleRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleRepository.swift; sourceTree = "<group>"; };
+		B4C4E7CB2A208379000859DD /* ImageFetchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetchable.swift; sourceTree = "<group>"; };
+		B4C4E7CF2A2087A2000859DD /* ImagableModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagableModel.swift; sourceTree = "<group>"; };
 		B4E5C5412A1C823B00B14F48 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		B4E5C5692A1C9E3E00B14F48 /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
 		B4E5C56B2A1CAC0C00B14F48 /* ImageFileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileStorage.swift; sourceTree = "<group>"; };
@@ -192,6 +200,7 @@
 			isa = PBXGroup;
 			children = (
 				B44EA8B82A1B311F008A83FF /* ClothesEntity.swift */,
+				B4C4E7C72A2077C7000859DD /* StyleEntity.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -288,6 +297,7 @@
 		B46CB8CD2A14888600039F72 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B4C4E7CE2A208797000859DD /* Protocol */,
 				B4470B552A1743130024B2B7 /* ClothesList.swift */,
 				B43889A12A14AD8800476BFC /* Clothes.swift */,
 				B438899F2A14ACF600476BFC /* ClothesCategory.swift */,
@@ -332,7 +342,9 @@
 		B46CB8D72A1489E800039F72 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				B4C4E7CD2A2083A1000859DD /* Protocol */,
 				B46111422A1F481200104C3A /* ClothesRepository.swift */,
+				B4C4E7C92A207A03000859DD /* StyleRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -400,6 +412,22 @@
 				B4B456802A1F9A66003354F8 /* StyleAddClothesController.swift */,
 			);
 			path = Style;
+			sourceTree = "<group>";
+		};
+		B4C4E7CD2A2083A1000859DD /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				B4C4E7CB2A208379000859DD /* ImageFetchable.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		B4C4E7CE2A208797000859DD /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				B4C4E7CF2A2087A2000859DD /* ImagableModel.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		B4D95D492A19E161009C8931 /* Clothes */ = {
@@ -558,6 +586,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B438899E2A14AB8E00476BFC /* UIViewController+NavigationTitle.swift in Sources */,
+				B4C4E7D02A2087A2000859DD /* ImagableModel.swift in Sources */,
 				B44EA8BE2A1B4AEE008A83FF /* Style.swift in Sources */,
 				B4C4E7C62A20526C000859DD /* StyleAddClothesCell.swift in Sources */,
 				B4504B762A1DF7030018C9BC /* FilterTitleHeaderView.swift in Sources */,
@@ -570,6 +599,7 @@
 				B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */,
 				B4470B562A1743130024B2B7 /* ClothesList.swift in Sources */,
 				B4504B6F2A1DEA9A0018C9BC /* FilterCell.swift in Sources */,
+				B4C4E7CC2A208379000859DD /* ImageFetchable.swift in Sources */,
 				B43889A92A14B7E600476BFC /* ClothesCell.swift in Sources */,
 				B46111432A1F481200104C3A /* ClothesRepository.swift in Sources */,
 				B43889A62A14B22100476BFC /* UIViewController+Preview.swift in Sources */,
@@ -577,6 +607,7 @@
 				B43889B32A150BF500476BFC /* ClothesCarouselCell.swift in Sources */,
 				B49CAAD52A1B8AD6008254C7 /* UIImage+Collage.swift in Sources */,
 				B4F1F42E2A18D81000DA6358 /* WeatherType.swift in Sources */,
+				B4C4E7CA2A207A03000859DD /* StyleRepository.swift in Sources */,
 				B4470B582A17461E0024B2B7 /* AddClothesCell.swift in Sources */,
 				B43889AD2A14B92600476BFC /* UICollectionView+RegisterDeque.swift in Sources */,
 				B4F1F4342A19001200DA6358 /* AddPhotoButton.swift in Sources */,
@@ -601,6 +632,7 @@
 				B4F1F4362A1914DF00DA6358 /* PhotoPicker.swift in Sources */,
 				B43889A22A14AD8800476BFC /* Clothes.swift in Sources */,
 				B4B456812A1F9A67003354F8 /* StyleAddClothesController.swift in Sources */,
+				B4C4E7C82A2077C7000859DD /* StyleEntity.swift in Sources */,
 				B4504B6A2A1DE9EF0018C9BC /* ClothesFilterController.swift in Sources */,
 				B44EA8B92A1B311F008A83FF /* ClothesEntity.swift in Sources */,
 				B46CB8B82A14739F00039F72 /* SceneDelegate.swift in Sources */,

--- a/EasyCloset/EasyCloset/Sources/Data/Model/StyleEntity.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Model/StyleEntity.swift
@@ -1,0 +1,43 @@
+//
+//  StyleEntity.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/26.
+//
+
+import Foundation
+
+import RealmSwift
+
+final class StyleEntity: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var createdAt: Date
+  @Persisted var clothes: List<ClothesEntity>
+  @Persisted var weatherType: Int
+  @Persisted var name: String
+  
+  convenience init(id: String,
+                   createdAt: Date,
+                   clothes: [ClothesEntity],
+                   weatherType: Int,
+                   name: String) {
+    self.init()
+    self.id = id
+    self.createdAt = createdAt
+    self.clothes = clothes.reduce(into: List<ClothesEntity>()) { $0.append($1) } // Array 형태를 Realm의 List로 매핑
+    self.weatherType = weatherType
+    self.name = name
+  }
+}
+
+// MARK: - Model Mapping
+extension StyleEntity {
+  func toModelWithoutImage() -> Style {
+    return Style(uuid: UUID(uuidString: id) ?? UUID(),
+                 createdAt: createdAt,
+                 clothes: clothes.map { $0.toModelWithoutImage() }.toClothesDictionary(),
+                 weather: WeatherType(rawValue: weatherType) ?? .allWeather,
+                 name: name,
+                 collageImage: nil)
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/Data/Repository/Protocol/ImageFetchable.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Repository/Protocol/ImageFetchable.swift
@@ -1,0 +1,45 @@
+//
+//  ImageFetchable.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/26.
+//
+
+import Foundation
+
+import Combine
+import UIKit
+
+protocol ImageFetchable {
+  var imageCacheManager: ImageCacheManager { get }
+  var imageFileStorage: ImageFileStorageProtocol { get }
+  func addingImages<T: ImagableModel>(to imagableModels: [T]) -> AnyPublisher<[T], Never>
+}
+
+extension ImageFetchable {
+  var imageCacheManager: ImageCacheManager { .shared }
+  var imageFileStorage: ImageFileStorageProtocol { ImageFileStorage.shared }
+  
+  func addingImages<T: ImagableModel>(to imagableModels: [T]) -> AnyPublisher<[T], Never> {
+    let modelsWithImagePublishers: [AnyPublisher<T, Never>] = imagableModels.map { imagableModel in
+      if let image = imageCacheManager.get(for: imagableModel.id) {
+        var model = imagableModel
+        model.image = image
+        return Just(model).eraseToAnyPublisher()
+      }
+      
+      return imageFileStorage.load(withID: imagableModel.id)
+        .replaceError(with: UIImage())
+        .map { image in
+          var model = imagableModel
+          model.image = image
+          return model
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    return Publishers.MergeMany(modelsWithImagePublishers)
+      .collect()
+      .eraseToAnyPublisher()
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/Data/Repository/Protocol/ImageFetchable.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Repository/Protocol/ImageFetchable.swift
@@ -20,6 +20,7 @@ extension ImageFetchable {
   var imageCacheManager: ImageCacheManager { .shared }
   var imageFileStorage: ImageFileStorageProtocol { ImageFileStorage.shared }
   
+  // storage에 저장된 이미지가 아직 로딩되지 않은 모델들에 이미지를 추가해서 매핑해줌
   func addingImages<T: ImagableModel>(to imagableModels: [T]) -> AnyPublisher<[T], Never> {
     let modelsWithImagePublishers: [AnyPublisher<T, Never>] = imagableModels.map { imagableModel in
       if let image = imageCacheManager.get(for: imagableModel.id) {

--- a/EasyCloset/EasyCloset/Sources/Data/Repository/StyleRepository.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Repository/StyleRepository.swift
@@ -1,0 +1,100 @@
+//
+//  StyleRepository.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/26.
+//
+
+import UIKit
+import RealmSwift
+
+import Combine
+
+import Then
+
+// MARK: - Protocol
+
+protocol StyleRepositoryProtocol {
+  func fetchStyles() -> AnyPublisher<[Style], RepositoryError>
+  func save(style: Style) -> Future<Void, RepositoryError>
+  func removeAll()
+}
+
+// MARK: - ClothesRepository
+
+final class StyleRepository: StyleRepositoryProtocol, ImageFetchable {
+  
+  // MARK: - Properties
+  
+  static let shared = StyleRepository()
+  
+  private let realmStorage: RealmStorageProtocol
+  
+  private var cancellables = Set<AnyCancellable>()
+  
+  private init(realmStorage: RealmStorageProtocol = RealmStorage.shared) {
+    self.realmStorage = realmStorage
+    setupMockData()
+  }
+  
+  // MARK: - Public Methods
+  
+  func fetchStyles() -> AnyPublisher<[Style], RepositoryError> {
+    return Future { [weak self] promise in
+      guard let self = self else { return }
+      
+      let styleEntities = realmStorage.load(entityType: StyleEntity.self)
+      let styleModels = styleEntities.map { $0.toModelWithoutImage() }
+      
+      // 내부의 clothes들에 이미지가 반영된 style 객체들
+      let styleWithImagePublishers = styleModels.map { style in
+        let clothes = style.clothes.values.map { $0 }
+        
+        return self.addingImages(to: clothes)
+          .map { clothesWithImages -> Style in
+            var newStyle = style
+            newStyle.clothes = clothesWithImages.toClothesDictionary()
+            return newStyle
+          }
+      }
+      
+      // 각각의 style들을 배열 값으로 한 번에 내보내도록 처리
+      Publishers.MergeMany(styleWithImagePublishers)
+        .collect()
+        .sink { styles in
+          promise(.success(styles))
+        }
+        .store(in: &cancellables)
+    }
+    .eraseToAnyPublisher()
+  }
+  
+  func save(style: Style) -> Future<Void, RepositoryError> {
+    return Future { [weak self] promise in
+      guard let self = self else { return }
+      
+      let styleEntity = style.toEntity()
+      if self.realmStorage.save(styleEntity) == false {
+        promise(.failure(.failToSave))
+      }
+    }
+  }
+  
+  func removeAll() {
+    realmStorage.removeAll(entityType: StyleEntity.self)
+  }
+  
+  // MARK: - Private Methods
+  
+  // 초기 데이터가 없을 때 테스트 용도로 Mock 데이터를 저장 해 주는 메서드
+#if DEBUG
+  private func setupMockData() {
+    guard realmStorage.load(entityType: StyleEntity.self).isEmpty else { return }
+    Style.mocks.forEach {
+      save(style: $0)
+        .sink(receiveCompletion: { _ in }, receiveValue: { })
+        .store(in: &cancellables)
+    }
+  }
+#endif
+}

--- a/EasyCloset/EasyCloset/Sources/Model/Clothes.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/Clothes.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct Clothes: Hashable {
+struct Clothes: Hashable, ImagableModel {
   let id: UUID
   let createdAt: Date
   var image: UIImage?
@@ -33,6 +33,12 @@ struct Clothes: Hashable {
 // MARK: - [Clothes] 를 ClothesList 타입으로 변환
 // Why: dictionary 의 key값으로 category를 매칭시켜 각 옷 종류에 따른 옷들에 접근 시 O(1)으로 접근하게 하기 위함
 extension Array where Element == Clothes {
+  func toClothesDictionary() -> [ClothesCategory: Clothes] {
+    return reduce(into: [ClothesCategory: Clothes](), { result, clothes in
+      result[clothes.category] = clothes
+    })
+  }
+  
   func toClothesList() -> ClothesList {
     return reduce(into: ClothesList(clothesByCategory: [:]), { result, clothes in
       result.clothesByCategory[clothes.category, default: []].append(clothes)

--- a/EasyCloset/EasyCloset/Sources/Model/Protocol/ImagableModel.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/Protocol/ImagableModel.swift
@@ -1,0 +1,14 @@
+//
+//  ImagableModel.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/26.
+//
+
+import UIKit
+
+// Repository에서 객체에 이미지를 storage에서 가져와서 매핑하기 위한 모델
+protocol ImagableModel {
+  var id: UUID { get }
+  var image: UIImage? { get set }
+}

--- a/EasyCloset/EasyCloset/Sources/Model/Style.swift
+++ b/EasyCloset/EasyCloset/Sources/Model/Style.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 struct Style: Hashable {
-  let uuid: UUID
-  var createdAt: Date
+  let id: UUID
+  let createdAt: Date
   var clothes: [ClothesCategory: Clothes]
   var weather: WeatherType
   var name: String?
@@ -21,11 +21,23 @@ struct Style: Hashable {
        weather: WeatherType,
        name: String? = nil,
        collageImage: UIImage? = nil) {
-    self.uuid = uuid
+    self.id = uuid
     self.createdAt = createdAt
     self.clothes = clothes
     self.weather = weather
     self.name = name
+  }
+}
+
+// MARK: - Entity Mapping
+
+extension Style {
+  func toEntity() -> StyleEntity {
+    StyleEntity(id: id.uuidString,
+                createdAt: createdAt,
+                clothes: clothes.values.map { $0.toEntity() },
+                weatherType: weather.rawValue,
+                name: name ?? "")
   }
 }
 


### PR DESCRIPTION
## Repository Protoco분리, POP 구현

> StyleRepository 를 구현하다 보니, Style 들을 가져올 때 각 스타일 내부에 있는 Clothes 객체에 이미지를 로딩해서 매핑해줘야 하는 작업이 똑같이 필요했음
> 
- ClothesRepository에서 가져오면 되는 것 아닌가?
    - 조금 비효율적인 면이 존재할 수 있지만, 각각의 Repository가 별개로 동작하는 것이 더 적절하겠다고 생각했기에 별도로 구현함.
- 공통되는 부분: 이미지를 가져와서 로딩하는 부분…
    - 이미지 캐시 매니저, 이미지 파일 스토리지 프로퍼티와 
    이미지를 Clothes 객체에 매핑해주는 부분을 프로토콜로 추상화함

```swift
protocol ImageFetchable {
  var imageCacheManager: ImageCacheManager { get }
  var imageFileStorage: ImageFileStorageProtocol { get }
  func addingImages(to clothesModels: [Clothes]) -> AnyPublisher<[Clothes], Never>
}

extension ImageFetchable {
  var imageCacheManager: ImageCacheManager { .shared }
  var imageFileStorage: ImageFileStorageProtocol { ImageFileStorage.shared }
  
  func addingImages(to clothesModels: [Clothes]) -> AnyPublisher<[Clothes], Never> {
    let clothesWithImagePublishers: [AnyPublisher<Clothes, Never>] = clothesModels.map { model in
      if let image = imageCacheManager.get(for: model.id) {
        var clothes = model
        clothes.image = image
        return Just(clothes).eraseToAnyPublisher()
      }
      
      return imageFileStorage.load(withID: model.id)
        .replaceError(with: UIImage())
        .map { image in
          var clothes = model
          clothes.image = image
          return clothes
        }
        .eraseToAnyPublisher()
    }
    
    return Publishers.MergeMany(clothesWithImagePublishers)
      .collect()
      .eraseToAnyPublisher()
  }
}
```

- 이런 식으로 이미지를 매핑 해 주는 부분을 protocol extension 으로 뺐음.

- 근데 이런 방식은 오직 Clothes 에만 이미지를 매핑할 수 있으므로, 
이미지를 매핑 받을 수 있는 protocol 타입을 정의하여 제네릭으로 차후 다른 모델 객체들도 이미지를 매핑할 수 있게 만들어주고 싶었음
- 이미지를 불러올 때 필요한 정보는 id값과 image 프로퍼티 두 가지만 필요함!

```swift
protocol ImagableModel {
  var id: UUID { get }
  // 이미지를 매핑할 때 저장할 수 있어야 하므로 get set 둘 다 제약을 줌
  var image: UIImage? { get set }
}
```

```swift
protocol ImageFetchable {
  var imageCacheManager: ImageCacheManager { get }
  var imageFileStorage: ImageFileStorageProtocol { get }
  func addingImages<T: ImagableModel>(to imagableModels: [T]) -> AnyPublisher<[T], Never>
}

extension ImageFetchable {
  var imageCacheManager: ImageCacheManager { .shared }
  var imageFileStorage: ImageFileStorageProtocol { ImageFileStorage.shared }
  
  func addingImages<T: ImagableModel>(to imagableModels: [T]) -> AnyPublisher<[T], Never> {
    let modelsWithImagePublishers: [AnyPublisher<T, Never>] = imagableModels.map { imagableModel in
      if let image = imageCacheManager.get(for: imagableModel.id) {
        var model = imagableModel
        model.image = image
        return Just(model).eraseToAnyPublisher()
      }
      
      return imageFileStorage.load(withID: imagableModel.id)
        .replaceError(with: UIImage())
        .map { image in
          var model = imagableModel
          model.image = image
          return model
        }
        .eraseToAnyPublisher()
    }
    
    return Publishers.MergeMany(modelsWithImagePublishers)
      .collect()
      .eraseToAnyPublisher()
  }
}
```

이렇게 제네릭을 줌으로서, 이미지를 가질 수 있는 (ImagebleModel을 채택한) 어떤 타입의 모델에 대해서도 매핑이 가능하게 됐음