### PR TITLE
[Refactor] combine 로직 리팩터링

### DIFF
--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		B4C4E7C62A20526C000859DD /* StyleAddClothesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7C52A20526C000859DD /* StyleAddClothesCell.swift */; };
 		B4C4E7C82A2077C7000859DD /* StyleEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7C72A2077C7000859DD /* StyleEntity.swift */; };
 		B4C4E7CA2A207A03000859DD /* StyleRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7C92A207A03000859DD /* StyleRepository.swift */; };
-		B4C4E7CC2A208379000859DD /* ImageFetchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7CB2A208379000859DD /* ImageFetchable.swift */; };
+		B4C4E7CC2A208379000859DD /* ImageFetchableRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7CB2A208379000859DD /* ImageFetchableRepository.swift */; };
 		B4C4E7D02A2087A2000859DD /* ImagableModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7CF2A2087A2000859DD /* ImagableModel.swift */; };
 		B4C4E7D22A2094C7000859DD /* StyleDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7D12A2094C7000859DD /* StyleDetailViewModel.swift */; };
 		B4C4E7D62A20ED9B000859DD /* RepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7D52A20ED9B000859DD /* RepositoryError.swift */; };
@@ -142,7 +142,7 @@
 		B4C4E7C52A20526C000859DD /* StyleAddClothesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleAddClothesCell.swift; sourceTree = "<group>"; };
 		B4C4E7C72A2077C7000859DD /* StyleEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleEntity.swift; sourceTree = "<group>"; };
 		B4C4E7C92A207A03000859DD /* StyleRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleRepository.swift; sourceTree = "<group>"; };
-		B4C4E7CB2A208379000859DD /* ImageFetchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetchable.swift; sourceTree = "<group>"; };
+		B4C4E7CB2A208379000859DD /* ImageFetchableRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetchableRepository.swift; sourceTree = "<group>"; };
 		B4C4E7CF2A2087A2000859DD /* ImagableModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagableModel.swift; sourceTree = "<group>"; };
 		B4C4E7D12A2094C7000859DD /* StyleDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleDetailViewModel.swift; sourceTree = "<group>"; };
 		B4C4E7D52A20ED9B000859DD /* RepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryError.swift; sourceTree = "<group>"; };
@@ -433,7 +433,7 @@
 		B4C4E7D72A20EDA9000859DD /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				B4C4E7CB2A208379000859DD /* ImageFetchable.swift */,
+				B4C4E7CB2A208379000859DD /* ImageFetchableRepository.swift */,
 				B4C4E7D52A20ED9B000859DD /* RepositoryError.swift */,
 			);
 			path = Common;
@@ -608,7 +608,7 @@
 				B4E5C5422A1C823B00B14F48 /* ImageCacheManager.swift in Sources */,
 				B4470B562A1743130024B2B7 /* ClothesList.swift in Sources */,
 				B4504B6F2A1DEA9A0018C9BC /* FilterCell.swift in Sources */,
-				B4C4E7CC2A208379000859DD /* ImageFetchable.swift in Sources */,
+				B4C4E7CC2A208379000859DD /* ImageFetchableRepository.swift in Sources */,
 				B43889A92A14B7E600476BFC /* ClothesCell.swift in Sources */,
 				B46111432A1F481200104C3A /* ClothesRepository.swift in Sources */,
 				B43889A62A14B22100476BFC /* UIViewController+Preview.swift in Sources */,

--- a/EasyCloset/EasyCloset/Sources/Data/Repository/ClothesRepository.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Repository/ClothesRepository.swift
@@ -22,7 +22,7 @@ protocol ClothesRepositoryProtocol {
 
 // MARK: - ClothesRepository
 
-final class ClothesRepository: ClothesRepositoryProtocol, ImageFetchable {
+final class ClothesRepository: ClothesRepositoryProtocol, ImageFetchableRepository {
   
   // MARK: - Properties
   
@@ -45,7 +45,6 @@ final class ClothesRepository: ClothesRepositoryProtocol, ImageFetchable {
     let clothesModelsWithoutImage = clothesEntities.map { $0.toModelWithoutImage() }
     return addingImages(to: clothesModelsWithoutImage)
       .map { $0.toClothesList() }
-      .mapError { _ in RepositoryError.invalidData }
       .eraseToAnyPublisher()
   }
   

--- a/EasyCloset/EasyCloset/Sources/Data/Repository/StyleRepository.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Repository/StyleRepository.swift
@@ -22,7 +22,7 @@ protocol StyleRepositoryProtocol {
 
 // MARK: - ClothesRepository
 
-final class StyleRepository: StyleRepositoryProtocol, ImageFetchable {
+final class StyleRepository: StyleRepositoryProtocol, ImageFetchableRepository {
   
   // MARK: - Properties
   
@@ -60,7 +60,6 @@ final class StyleRepository: StyleRepositoryProtocol, ImageFetchable {
     // 각각의 style들을 배열 값으로 한 번에 내보내도록 처리
     return Publishers.MergeMany(styleWithImagePublishers)
       .collect()
-      .mapError { _ in RepositoryError.invalidData }
       .eraseToAnyPublisher()
   }
   


### PR DESCRIPTION
- 불필요한 Future 제거
- 이미 내부의 ImageFileStorage에서 가져오는 로직이 Future를 호출하기 때문에, 중첩되게 future를 하지 않아도 된다 판단했고 eraseToAnypublisher로 지워서 내보내게끔 함
- 또한 ImageFetchable 에서 input 데이터가 비었을 경우 RepositoryError 를 내뱉게끔 함

```swift
final class ClothesRepository {
 func fetchClothesList() -> AnyPublisher<ClothesList, RepositoryError> {
    let clothesEntities = realmStorage.load(entityType: ClothesEntity.self)
    let clothesModelsWithoutImage = clothesEntities.map { $0.toModelWithoutImage() }
    return addingImages(to: clothesModelsWithoutImage)
      .map { $0.toClothesList() }
      .eraseToAnyPublisher()
  }
}
```

```swift
extension ImageFetchableRepository {
  var imageCacheManager: ImageCacheManager { .shared }
  
  // storage에 저장된 이미지가 아직 로딩되지 않은 모델들에 이미지를 추가해서 매핑해줌
  func addingImages<T: ImagableModel>(to imagableModels: [T]) -> AnyPublisher<[T], RepositoryError> {
    // 모델이 비어있으면 fail 반환
    guard imagableModels.isEmpty == false else {
      return Fail(error: RepositoryError.invalidData)
        .eraseToAnyPublisher()
    }
    
    let modelsWithImagePublishers = imagableModels.map { imagableModel in
      if let image = imageCacheManager.get(for: imagableModel.id) {
        var model = imagableModel
        model.image = image
        return Just(model)
          .setFailureType(to: RepositoryError.self)
          .eraseToAnyPublisher()
      }
      
      return imageFileStorage.load(withID: imagableModel.id)
        .replaceError(with: UIImage())
        .map { image in
          var model = imagableModel
          model.image = image
          return model
        }
        .setFailureType(to: RepositoryError.self)
        .eraseToAnyPublisher()
    }
    
    return Publishers.MergeMany(modelsWithImagePublishers)
      .collect()
      .eraseToAnyPublisher()
  }
}
```