### PR TITLE
[Feat] 삭제/상세보기 메뉴, 삭제 기능 구현

### DIFF
--- a/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
+++ b/EasyCloset/EasyCloset.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		B49CAAD12A1B5455008254C7 /* StyleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD02A1B5455008254C7 /* StyleViewModel.swift */; };
 		B49CAAD52A1B8AD6008254C7 /* UIImage+Collage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */; };
 		B4B456812A1F9A67003354F8 /* StyleAddClothesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B456802A1F9A66003354F8 /* StyleAddClothesController.swift */; };
+		B4B50C052A25066E002DE5E8 /* MenuConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B50C042A25066E002DE5E8 /* MenuConfigurable.swift */; };
 		B4BE982D2A238C120074D73C /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = B4BE982C2A238C120074D73C /* Realm */; };
 		B4BE982F2A238C120074D73C /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B4BE982E2A238C120074D73C /* RealmSwift */; };
 		B4C4E7C62A20526C000859DD /* StyleAddClothesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C4E7C52A20526C000859DD /* StyleAddClothesCell.swift */; };
@@ -165,6 +166,7 @@
 		B49CAAD02A1B5455008254C7 /* StyleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleViewModel.swift; sourceTree = "<group>"; };
 		B49CAAD42A1B8AD6008254C7 /* UIImage+Collage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Collage.swift"; sourceTree = "<group>"; };
 		B4B456802A1F9A66003354F8 /* StyleAddClothesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleAddClothesController.swift; sourceTree = "<group>"; };
+		B4B50C042A25066E002DE5E8 /* MenuConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuConfigurable.swift; sourceTree = "<group>"; };
 		B4C4E7C52A20526C000859DD /* StyleAddClothesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleAddClothesCell.swift; sourceTree = "<group>"; };
 		B4C4E7C72A2077C7000859DD /* StyleEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleEntity.swift; sourceTree = "<group>"; };
 		B4C4E7C92A207A03000859DD /* StyleRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleRepository.swift; sourceTree = "<group>"; };
@@ -540,6 +542,7 @@
 				B4F1F4242A18C1FF00DA6358 /* Highlightable.swift */,
 				B43889AA2A14B8F300476BFC /* ReusableView.swift */,
 				B4470B5B2A176C3A0024B2B7 /* ShadowableCellType.swift */,
+				B4B50C042A25066E002DE5E8 /* MenuConfigurable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -733,6 +736,7 @@
 				B43889AF2A14C56500476BFC /* CarouselFlowLayout.swift in Sources */,
 				B4F1F4232A18AD9700DA6358 /* UITabBarController+Transition.swift in Sources */,
 				B4684F0A2A23612C00EAD18F /* UIViewController+Keyboard.swift in Sources */,
+				B4B50C052A25066E002DE5E8 /* MenuConfigurable.swift in Sources */,
 				B4C8D1062A224CB100A465F9 /* UIViewController+ShowAlert.swift in Sources */,
 				B4470B502A1734780024B2B7 /* ClothesCategoryHeaderView.swift in Sources */,
 				B461114B2A1F827600104C3A /* StyleDetailCell.swift in Sources */,

--- a/EasyCloset/EasyCloset/Sources/Data/Repository/StyleRepository.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Repository/StyleRepository.swift
@@ -17,6 +17,7 @@ import Then
 protocol StyleRepositoryProtocol {
   func fetchStyles() -> AnyPublisher<[Style], RepositoryError>
   func save(style: Style) -> AnyPublisher<Void, RepositoryError>
+  func remove(style: Style)
   func removeAll()
 }
 
@@ -78,6 +79,14 @@ final class StyleRepository: StyleRepositoryProtocol, ImageFetchableRepository {
       promise(.failure(.failToSave))
     }
     .eraseToAnyPublisher()
+  }
+  
+  func remove(style: Style) {
+    realmStorage.remove(id: style.id.uuidString, entityType: StyleEntity.self)
+    imageFileStorage.remove(withID: style.id)
+    // 딱히 삭제에 대한 에러 처리를 할 필요가 없기에 단순히 무응답 클로저로 남김
+      .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+      .store(in: &cancellables)
   }
   
   func removeAll() {

--- a/EasyCloset/EasyCloset/Sources/Data/Storage/RealmStorage.swift
+++ b/EasyCloset/EasyCloset/Sources/Data/Storage/RealmStorage.swift
@@ -17,7 +17,7 @@ import Then
 protocol RealmStorageProtocol {
   func load<T: Object>(entityType: T.Type) -> [T]
   @discardableResult func save<T: Object>(_ data: T) -> Bool
-  @discardableResult func remove<T: Object>(entity: T) -> Bool
+  @discardableResult func remove<T: Object>(id: String, entityType: T.Type) -> Bool
   func removeAll<T: Object>(entityType: T.Type)
 }
 
@@ -54,12 +54,16 @@ final class RealmStorage: RealmStorageProtocol {
     }
   }
   
-  func remove<T: Object>(entity: T) -> Bool {
+  func remove<T: Object>(id: String, entityType: T.Type) -> Bool {
     guard let realm = realm else { return false }
+    
+    guard let object = realm.object(ofType: entityType.self, forPrimaryKey: id) else {
+      return false
+    }
     
     do {
       try realm.write {
-        realm.delete(entity)
+        realm.delete(object)
       }
       return true
     } catch {

--- a/EasyCloset/EasyCloset/Sources/View/Clothes/ClothesCarouselCell.swift
+++ b/EasyCloset/EasyCloset/Sources/View/Clothes/ClothesCarouselCell.swift
@@ -12,6 +12,7 @@ import Combine
 protocol ClothesCarouselCellDelegate: AnyObject {
   func clothesCarouselCell(_ cell: ClothesCarouselCell, showClothesDetail clothes: Clothes)
   func clothesCarouselCell(_ cell: ClothesCarouselCell, addClothesOf categoty: ClothesCategory)
+  func clothesCarouselCell(_ cell: ClothesCarouselCell, deleteClothes clothes: Clothes)
 }
 
 /// Clothes화면의 각 행에 해당함 (외투 목록, 상의 목록...)
@@ -148,7 +149,20 @@ extension ClothesCarouselCell {
 
 extension ClothesCarouselCell: UICollectionViewDelegate {
   
-  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+  func collectionView(_ collectionView: UICollectionView,
+                      didSelectItemAt indexPath: IndexPath) {
+   moveToSelectedItem(at: indexPath)
+  }
+
+  func collectionView(_ collectionView: UICollectionView,
+                      contextMenuConfigurationForItemAt indexPath: IndexPath,
+                      point: CGPoint) -> UIContextMenuConfiguration? {
+    return configureMenuConfiguration(of: indexPath)
+  }
+}
+
+extension ClothesCarouselCell: MenuConfigurable {
+  func moveToSelectedItem(at indexPath: IndexPath) {
     guard let item = dataSource.itemIdentifier(for: indexPath),
           let category = category else { return }
     
@@ -161,11 +175,17 @@ extension ClothesCarouselCell: UICollectionViewDelegate {
     case .clothes(let clothes):
       delegate?.clothesCarouselCell(self, showClothesDetail: clothes)
     }
-
+    
     // 자연스럽게 보이도록 0.5초 후에 해당 위치로 scroll
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
       self.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
     }
+  }
+  
+  func deleteSelectedItem(of indexPath: IndexPath) {
+    guard let item = dataSource.itemIdentifier(for: indexPath),
+          case let .clothes(clotehs) = item else { return }
+    delegate?.clothesCarouselCell(self, deleteClothes: clotehs)
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/View/Clothes/ClothesCarouselCell.swift
+++ b/EasyCloset/EasyCloset/Sources/View/Clothes/ClothesCarouselCell.swift
@@ -161,7 +161,10 @@ extension ClothesCarouselCell: UICollectionViewDelegate {
   }
 }
 
+// MARK: - MenuConfigurable
+
 extension ClothesCarouselCell: MenuConfigurable {
+  
   func moveToSelectedItem(at indexPath: IndexPath) {
     guard let item = dataSource.itemIdentifier(for: indexPath),
           let category = category else { return }

--- a/EasyCloset/EasyCloset/Sources/View/Protocol/MenuConfigurable.swift
+++ b/EasyCloset/EasyCloset/Sources/View/Protocol/MenuConfigurable.swift
@@ -1,0 +1,37 @@
+//
+//  MenuConfigurable.swift
+//  EasyCloset
+//
+//  Created by Mason Kim on 2023/05/30.
+//
+
+import UIKit
+
+/// 특정 아이템을 꾹 눌렀을 때 상세보기 / 삭제 를 구현하기 위한 Protocol
+protocol MenuConfigurable {
+  /// 선택된 아이템으로 이동
+  func moveToSelectedItem(at indexPath: IndexPath)
+  /// 선택된 아이템을 삭제
+  func deleteSelectedItem(of indexPath: IndexPath)
+  func configureMenuConfiguration(of indexPath: IndexPath) -> UIContextMenuConfiguration?
+}
+
+extension MenuConfigurable {
+  func configureMenuConfiguration(of indexPath: IndexPath) -> UIContextMenuConfiguration? {
+    guard indexPath.row != 0 else { return nil }
+    
+    let showDetailAction = UIAction(title: "상세 보기", image: UIImage(systemName: "eye"),
+                                    handler: { _ in
+      self.moveToSelectedItem(at: indexPath)
+    })
+    let deleteAction = UIAction(title: "삭제", image: UIImage(systemName: "trash.slash"),
+                                attributes: .destructive, handler: { _ in
+      self.deleteSelectedItem(of: indexPath)
+    })
+    
+    let menuItems = [showDetailAction, deleteAction]
+    return UIContextMenuConfiguration(actionProvider: { _ in
+      UIMenu(title: "", options: [], children: menuItems)
+    })
+  }
+}

--- a/EasyCloset/EasyCloset/Sources/ViewController/Clothes/ClothesController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/Clothes/ClothesController.swift
@@ -194,11 +194,10 @@ extension ClothesController: ClothesCarouselCellDelegate {
   }
   
   func clothesCarouselCell(_ cell: ClothesCarouselCell, deleteClothes clothes: Clothes) {
-    showAskAlert(title: "정말 삭제하시겠습니까?") { isDelete in
+    showAskAlert(title: "정말 삭제하시겠습니까?") { [weak self] isDelete in
       guard isDelete else { return }
-      
+      self?.viewModel.deleteClothes.send(clothes)
     }
-    print("삭제삭제?!?!? : \(clothes)")
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/ViewController/Clothes/ClothesController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/Clothes/ClothesController.swift
@@ -182,17 +182,23 @@ extension ClothesController: UICollectionViewDelegateFlowLayout {
 extension ClothesController: ClothesCarouselCellDelegate {
   
   func clothesCarouselCell(_ cell: ClothesCarouselCell, showClothesDetail clothes: Clothes) {
-    
     let detailController = DIContainer.shared.makeClothesDetailController(type: .showDetail(clothes: clothes))
     detailController.delegate = self
     navigationController?.pushViewController(detailController, animated: true)
   }
   
   func clothesCarouselCell(_ cell: ClothesCarouselCell, addClothesOf categoty: ClothesCategory) {
-    
     let detailController = DIContainer.shared.makeClothesDetailController(type: .add)
     detailController.delegate = self
     navigationController?.pushViewController(detailController, animated: true)
+  }
+  
+  func clothesCarouselCell(_ cell: ClothesCarouselCell, deleteClothes clothes: Clothes) {
+    showAskAlert(title: "정말 삭제하시겠습니까?") { isDelete in
+      guard isDelete else { return }
+      
+    }
+    print("삭제삭제?!?!? : \(clothes)")
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/ViewController/Style/StyleController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/Style/StyleController.swift
@@ -149,10 +149,13 @@ extension StyleController: UICollectionViewDelegateFlowLayout {
 extension StyleController {
   override func collectionView(_ collectionView: UICollectionView,
                                didSelectItemAt indexPath: IndexPath) {
-    guard let style = dataSource.itemIdentifier(for: indexPath) else { return }
-    let detailController = DIContainer.shared.makeStyleDetailController(type: .showDetail(style: style))
-    detailController.delegate = self
-    navigationController?.pushViewController(detailController, animated: true)
+    moveToSelectedItem(at: indexPath)
+  }
+  
+  override func collectionView(_ collectionView: UICollectionView,
+                               contextMenuConfigurationForItemAt indexPath: IndexPath,
+                               point: CGPoint) -> UIContextMenuConfiguration? {
+    return configureMenuConfiguration(of: indexPath)
   }
 }
 
@@ -161,6 +164,28 @@ extension StyleController {
 extension StyleController: StyleDetailControllerDelegate {
   func styleDetailController(didUpdateOrSave viewController: StyleDetailController) {
     viewModel.stylesDidUpdate.send()
+  }
+}
+
+// MARK: - MenuConfigurable
+
+extension StyleController: MenuConfigurable {
+  
+  func moveToSelectedItem(at indexPath: IndexPath) {
+    guard let style = dataSource.itemIdentifier(for: indexPath) else { return }
+    
+    let detailController = DIContainer.shared.makeStyleDetailController(type: .showDetail(style: style))
+    detailController.delegate = self
+    navigationController?.pushViewController(detailController, animated: true)
+  }
+  
+  func deleteSelectedItem(of indexPath: IndexPath) {
+    guard let style = dataSource.itemIdentifier(for: indexPath) else { return }
+    
+    showAskAlert(title: "정말 삭제하시겠습니까?") { [weak self] isDelete in
+      guard isDelete else { return }
+      self?.viewModel.deleteStyle.send(style)
+    }
   }
 }
 

--- a/EasyCloset/EasyCloset/Sources/ViewModel/ClothesViewModel.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewModel/ClothesViewModel.swift
@@ -16,6 +16,7 @@ final class ClothesViewModel {
   @Published private var clothesList = ClothesList(clothesByCategory: [:])
   
   let searchFilters = CurrentValueSubject<FilterItems, Never>([.sort(.new)])
+  let deleteClothes = PassthroughSubject<Clothes, Never>()
   let clothesListDidUpdate = PassthroughSubject<Void, Never>()
   let clothesListDidEndUpdate = PassthroughSubject<Void, Never>()
   
@@ -56,6 +57,13 @@ final class ClothesViewModel {
       } receiveValue: { [weak self] clothesList in
         self?.clothesList = clothesList
         self?.clothesListDidEndUpdate.send()
+      }
+      .store(in: &cancellables)
+    
+    deleteClothes
+      .sink { [weak self] clothes in
+        self?.repository.remove(clothes: clothes)
+        self?.clothesListDidUpdate.send()
       }
       .store(in: &cancellables)
   }

--- a/EasyCloset/EasyCloset/Sources/ViewModel/StyleViewModel.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewModel/StyleViewModel.swift
@@ -14,7 +14,8 @@ final class StyleViewModel {
   // MARK: - Properties
   
   @Published private(set) var styles = [Style]()
-  
+
+  let deleteStyle = PassthroughSubject<Style, Never>()
   let stylesDidUpdate = PassthroughSubject<Void, Never>()
   
   private var cancellables = Set<AnyCancellable>()
@@ -43,6 +44,13 @@ final class StyleViewModel {
         }
       } receiveValue: { [weak self] styles in
         self?.styles = styles
+      }
+      .store(in: &cancellables)
+    
+    deleteStyle
+      .sink { [weak self] style in
+        self?.repository.remove(style: style)
+        self?.stylesDidUpdate.send()
       }
       .store(in: &cancellables)
   }

--- a/EasyCloset/EasyClosetTests/ImageCacheManagerTests.swift
+++ b/EasyCloset/EasyClosetTests/ImageCacheManagerTests.swift
@@ -16,12 +16,10 @@ final class ImageCacheManagerTests: XCTestCase {
   override func setUpWithError() throws {
     sut.countLimit = 100
     sut.megaByteLimit = 200
-    print("제한 초기화는 함")
   }
   
   override func tearDownWithError() throws {
     sut.removeAll()
-    print("끝나고 삭제도 함")
   }
   
   func test_이미지_캐싱_저장과_불러오기가_잘_이뤄지는지_확인() {


### PR DESCRIPTION
### 특정 아이템을 꾹 눌렀을 때 상세보기/삭제 메뉴 구현

```swift 
/// 특정 아이템을 꾹 눌렀을 때 상세보기 / 삭제 를 구현하기 위한 Protocol
protocol MenuConfigurable {
  /// 선택된 아이템으로 이동
  func moveToSelectedItem(at indexPath: IndexPath)
  /// 선택된 아이템을 삭제
  func deleteSelectedItem(of indexPath: IndexPath)
  func configureMenuConfiguration(of indexPath: IndexPath) -> UIContextMenuConfiguration?
}

extension MenuConfigurable {
  func configureMenuConfiguration(of indexPath: IndexPath) -> UIContextMenuConfiguration? {
    guard indexPath.row != 0 else { return nil }
    
    let showDetailAction = UIAction(title: "상세 보기", image: UIImage(systemName: "eye"),
                                    handler: { _ in
      self.moveToSelectedItem(at: indexPath)
    })
    let deleteAction = UIAction(title: "삭제", image: UIImage(systemName: "trash.slash"),
                                attributes: .destructive, handler: { _ in
      self.deleteSelectedItem(of: indexPath)
    })
    
    let menuItems = [showDetailAction, deleteAction]
    return UIContextMenuConfiguration(actionProvider: { _ in
      UIMenu(title: "", options: [], children: menuItems)
    })
  }
}
```

### [Fix] Realm 특정 엔터티 삭제 안되는 문제 해결

- Realm 에서 "생성"한 객체만 삭제가능하기에, 모델 객체를 entity 로 매핑해서 해당 entity를 삭제하려고 시도하니 앱이 멈추었음
- id 값을 바탕으로 entity를 가져오고 해당 entity를 삭제하는 방식으로 해결

```swift 
func remove<T: Object>(id: String, entityType: T.Type) -> Bool {
    guard let realm = realm else { return false }
    
    guard let object = realm.object(ofType: entityType.self, forPrimaryKey: id) else {
      return false
    }
    
    do {
      try realm.write {
        realm.delete(object)
```

### 옷 삭제 기능 구현 및 뷰모델과 바인딩
