### PR TITLE
[Fix] clothes filter가 적용되지 않는 문제 해결

### DIFF
--- a/EasyCloset/EasyCloset/Sources/ViewController/Clothes/ClothesController.swift
+++ b/EasyCloset/EasyCloset/Sources/ViewController/Clothes/ClothesController.swift
@@ -82,7 +82,7 @@ final class ClothesController: UIViewController {
   // MARK: - Private Methods
   
   private func bind() {
-    viewModel.$clothesList
+    viewModel.filteredClothesList
       .sink { [weak self] clothesList in
         self?.applySnapshot(with: clothesList)
       }

--- a/EasyCloset/EasyClosetTests/ClothesViewModelTests.swift
+++ b/EasyCloset/EasyClosetTests/ClothesViewModelTests.swift
@@ -45,54 +45,39 @@ final class ClothesViewModelTests: XCTestCase {
   
   func test_최신순_filter가_적용되는지_테스트() {
     // given
-    let categories = ClothesCategory.allCases
     sut.searchFilters.send([.sort(.new)])
+    let expectation = XCTestExpectation()
     
-    // 각각의 카테고리에 대한 expectation
-    var expectations: [XCTestExpectation] = []
-    
-    categories.forEach { category in
-      let expectation = XCTestExpectation(description: category.korean)
-      expectations.append(expectation)
-      
-      // when
-      sut.clothes(of: category)
-        .sink { clothes in
+    // when
+    sut.filteredClothesList
+      .sink { clothesList in
+        clothesList.clothesByCategory.forEach { category, clothes in
           let sortedClothes = clothes.sorted(by: { $0.createdAt > $1.createdAt })
-          
           // then
           XCTAssertEqual(clothes, sortedClothes)
-          expectation.fulfill()
         }
-        .store(in: &cancellables)
-    }
+        expectation.fulfill()
+      }
+      .store(in: &cancellables)
   }
   
   func test_계절_filter가_적용되는지_테스트() {
     // given
-    let categories = ClothesCategory.allCases
     let weatherFilterType: WeatherType = .fall
     sut.searchFilters.send([.weather(weatherFilterType)])
+    let expectation = XCTestExpectation()
     
-    // 각각의 카테고리에 대한 expectation
-    var expectations: [XCTestExpectation] = []
-    
-    categories.forEach { category in
-      let expectation = XCTestExpectation(description: category.korean)
-      expectations.append(expectation)
-      
-      // when
-      sut.clothes(of: category)
-        .sink { clothes in
-          
-          // then
+    // when
+    sut.filteredClothesList
+      .sink { clothesList in
+        clothesList.clothesByCategory.forEach { category, clothes in
           XCTAssertTrue(clothes.allSatisfy {
             $0.weatherType == weatherFilterType
           })
-          expectation.fulfill()
         }
-        .store(in: &cancellables)
-    }
+        expectation.fulfill()
+      }
+      .store(in: &cancellables)
   }
 
 }

--- a/EasyCloset/EasyClosetTests/Data/MockClothesRepository.swift
+++ b/EasyCloset/EasyClosetTests/Data/MockClothesRepository.swift
@@ -10,6 +10,7 @@
 import Combine
 
 final class MockClothesRepository: ClothesRepositoryProtocol {
+  
   func fetchClothesList() -> AnyPublisher<ClothesList, RepositoryError> {
     return Just(ClothesList.mocks)
       .setFailureType(to: RepositoryError.self)
@@ -20,6 +21,10 @@ final class MockClothesRepository: ClothesRepositoryProtocol {
     return Just(())
       .setFailureType(to: RepositoryError.self)
       .eraseToAnyPublisher()
+  }
+  
+  func remove(clothes: EasyCloset.Clothes) {
+    return
   }
   
   func removeAll() {

--- a/EasyCloset/EasyClosetTests/Data/MockStyleRepository.swift
+++ b/EasyCloset/EasyClosetTests/Data/MockStyleRepository.swift
@@ -22,6 +22,10 @@ final class MockStyleRepository: StyleRepositoryProtocol {
       .eraseToAnyPublisher()
   }
   
+  func remove(style: EasyCloset.Style) {
+    return
+  }
+  
   func removeAll() {
     return
   }


### PR DESCRIPTION
- 중첩 컬렉션뷰에서 단일 컬렉션뷰로 변경함으로서, viewModel의 바인딩 로직을 변경한 부분을 filter를 적용하지 않았던 부분 해결
  - 뷰컨이 뷰모델의 clothes(of:) 를 통해서가 아니라, clothesList를 직접 바라보고 데이터 바인딩 하는 로직으로 변경하며 filter를 적용해주는 부분을 변경하지 않았었음.